### PR TITLE
Migrate test suite + dev files (full GitHub migration)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+*.gz filter=lfs diff=lfs merge=lfs -text
+*.tlt filter=lfs diff=lfs merge=lfs -text
+*.eonnx filter=lfs diff=lfs merge=lfs -text
+*.nemo filter=lfs diff=lfs merge=lfs -text
+*.tar.gz filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.arpa filter=lfs diff=lfs merge=lfs -text
+tests/pointcloud_unit_tests/pointpillars/data/pointpillars_ptm.onnx filter=lfs diff=lfs merge=lfs -text
+tests/pointcloud_unit_tests/pointpillars/data/102.bin filter=lfs diff=lfs merge=lfs -text

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,78 @@
+Changelog
+=========
+
+Version 3.21.08
+---------------
+:Date: August 12, 2021
+Soul: Update TAO release for 3.21.08
+
+- Rename Jarvis to Riva
+- Rename TLT to TAO
+- Bug fixes from 3.21.08
+- Integrating superres base model to ToT
+- Update CI from gitlab runner to Blossom Jenkins pipeline
+- Add automated publishing of Dockers to the CI
+
+Version 3.0.17
+--------------
+:Date: April 10, 2021
+Soul: Schema-based validation of exported .ejrvs archives with EFF 0.3.1
+
+- Made -r command line arg mandatory to all TLT scripts for all workflows (!)
+- Schema-based validation
+  - Implemented validation schemes for .ejvrs files
+  - Added schema based validation to export
+  - Refactored unit tests to rely on schema validation
+- Workflows:
+  - ASR speech-to-text (Jasper/Quartznet)
+  - ASR speech-to-text (CitriNet)
+  - NLP text-classification (BERT)
+  - NLP text-classification (Megatron)
+  - NLP question-answering (BERT)
+  - NLP question-answering (Megatron)
+  - NLP intent and slot classification (BERT)
+  - NLP intent and slot classification (Megatron)
+  - NLP token classification (BERT)
+  - NLP punctuation and capitalization (BERT)
+- Text Classification with Megatron encoder (MR 104)
+- Joint Intent Classification and Slot Filling with Megatron encoder (MR 104)
+- Built and pushed a new docker image
+- Updated docker ID/sha in TLT configuration
+- Updated/optimized unit test for mockup models
+  - Test assuring all models have CRC sums assigned
+  - Made (un)encryption check lighter - retrieve only manifest
+- Bumped EFF dependency to 0.3.2
+- Added CHANGELOG file
+   
+Version 3.0.16
+--------------
+:Date: March 18, 2021
+Soul: QA Megatron on pytorch:21.02-py3
+
+- Updated BASE_IMAGE to pytorch:21.02-py3
+- Cleaned up/modified dependencies (removed onnx-graphsurgeon, PTL pinned to 1.1.3)
+- Built and pushed a new docker image
+- Updated docker ID/sha in TLT configuration
+- Bugfix: set encryption key for Megatron export
+- Speech to Text with CitriNet (MR 101)
+- QA with Megatron encoder (MR 103)
+  - QA BERT and Megatron training operational and covered with tests
+  - QA Megatron fine-tuning operational and covered with tests
+  - QA Megatron evaluation operational and covered with tests
+  - QA Megatron export operational and covered with tests
+  - QA Megatron inference operational and covered with tests
+  - QA Megatron ONNX inference operational and covered with tests
+
+
+Version 3.0.15
+--------------
+:Date: Feb 25, 2021
+Soul: Encryption key obfuscation
+  
+- Removed cmd log file (train, finetune, evaluate) in 6 workflows
+- Fixed download_specs
+- Reverted sys.args["encryption_key"] obfuscation
+- Removed generation of cmd log file from exp_minimal_manager
+- bumped version to 3.0.15
+- Pulling Vahid's NeMo fix pushed to 1.0.0b4 into this release (https://github.com/NVIDIA/NeMo/pull/1762)
+- Rebuilt and pushed the docker - updated docker sha!

--- a/coveragerc
+++ b/coveragerc
@@ -1,0 +1,11 @@
+[run]
+parallel = True
+source=
+## tao-pytorch
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_pytorch
+## tao-deploy
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_deploy
+## tao-dataservices
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_ds
+## tao-tf2
+    /usr/local/lib/python3.12/dist-packages/nvidia_tao_tf2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,23 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+
+# durations=0 will display all tests execution time, sorted in ascending order starting from from the slowest one.
+# -vv will also display tests with durration = 0.00s
+[pytest]
+addopts = --verbose --pyargs --durations=0
+markers =
+    unit: marks unit test, i.e. testing a single, well isolated functionality (deselect with '-m "not unit"')
+    train: tests related to train scripts (deselect with '-m "not train"')
+    finetune: tests related to fine tune scripts (deselect with '-m "not finetune"')
+    evaluate: tests related to fine tune scripts (deselect with '-m "not evaluate"')
+    export: tests related to export to ONNX scripts (deselect with '-m "not export"')
+    infer: tests related to inference scripts (deselect with '-m "not infer"')
+    infer_onnx: tests related to ONNX-based inference scripts (deselect with '-m "not infer_onnx"')
+    cv_unit: marks cv unit test (deselect with '-m "not cv_unit"')
+    multimodal_unit: marks multimodal unit test (deselect with '-m "not multimodal_unit"')
+    pointcloud_unit: marks point cloud unit test (deselect with '-m "not pointcloud_unit"')
+    sdg_unit: marks sdg unit test (deselect with '-m "not sdg_unit"')
+    tensorrt: marks tensorrt unit tests (deselect with '-m "not tensorrt"')
+    ocrnet: marks ocrnet related unit tests
+    ocdnet: marks ocdnet unit test (deselect with '-m "not ocdnet"')
+    config: unit test for configs (deselect with '-m "not config"')
+    schema_validation: unit test for schema validation (deselect with '-m "not schema_validation"')

--- a/tests/core/test_best_checkpoint.py
+++ b/tests/core/test_best_checkpoint.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for network-aware best-checkpoint saving."""
+
+import pytest
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from nvidia_tao_pytorch.core.lightning.tao_lightning_module import (
+    TAOLightningModule, validate_monitor_metric,
+)
+
+
+class _DummyModule(TAOLightningModule):
+    """Minimal concrete module to exercise configure_callbacks()."""
+
+    def __init__(self, spec, monitor="val_acc", mode="max"):
+        super().__init__(spec)
+        self.checkpoint_filename = "dummy_model"
+        self.monitor_metric = monitor
+        self.monitor_mode = mode
+
+
+def _spec(results_dir, checkpointer=None):
+    train = {"checkpoint_interval": 1, "checkpoint_interval_unit": "epoch"}
+    if checkpointer is not None:
+        train["checkpointer"] = checkpointer
+    return {"results_dir": str(results_dir), "dataset": {}, "model": {}, "train": train}
+
+
+def _best_callbacks(callbacks):
+    """ModelCheckpoints that actually monitor a metric (the 'best' ones)."""
+    return [c for c in callbacks if isinstance(c, ModelCheckpoint) and c.monitor is not None]
+
+
+def _periodic_callbacks(callbacks):
+    """Unbounded, unmonitored periodic ModelCheckpoints."""
+    return [
+        c for c in callbacks
+        if isinstance(c, ModelCheckpoint) and c.monitor is None and c.save_top_k == -1
+    ]
+
+
+def test_base_defaults_present():
+    m = TAOLightningModule.__new__(TAOLightningModule)  # no model build
+    TAOLightningModule.__init__(m, _spec("/tmp"))
+    assert m.monitor_metric == "val_loss"
+    assert m.monitor_mode == "min"
+
+
+def test_no_checkpointer_block_is_backward_compatible(tmp_path):
+    # Old spec: no 'checkpointer' key at all -> no monitored checkpoint appended.
+    m = _DummyModule(_spec(tmp_path))
+    cbs = m.configure_callbacks()
+    assert _best_callbacks(cbs) == []
+    assert len(_periodic_callbacks(cbs)) == 1
+
+
+def test_disabled_topk_appends_nothing(tmp_path):
+    m = _DummyModule(_spec(tmp_path, checkpointer={"enable_topk": False}))
+    callbacks = m.configure_callbacks()
+    assert _best_callbacks(callbacks) == []
+    assert len(_periodic_callbacks(callbacks)) == 1
+
+
+def test_replace_periodic_requires_topk_to_be_enabled(tmp_path):
+    cfg = {"enable_topk": False, "replace_periodic": True}
+    callbacks = _DummyModule(_spec(tmp_path, checkpointer=cfg)).configure_callbacks()
+    assert _best_callbacks(callbacks) == []
+    assert len(_periodic_callbacks(callbacks)) == 1
+
+
+def test_enabled_uses_network_default_metric(tmp_path):
+    m = _DummyModule(_spec(tmp_path, checkpointer={"enable_topk": True}),
+                     monitor="val_acc", mode="max")
+    best = _best_callbacks(m.configure_callbacks())
+    assert len(best) == 1
+    cb = best[0]
+    assert cb.monitor == "val_acc"
+    assert cb.mode == "max"
+    # best callback must not fight the periodic callback over *_latest, and must
+    # rank at validation end:
+    assert cb.save_last is False
+    assert cb._save_on_train_epoch_end is False
+    assert str(cb.dirpath) == str(tmp_path)   # defaults to results_dir
+    assert len(_periodic_callbacks(m.configure_callbacks())) == 1
+
+
+def test_replace_periodic_keeps_one_best_and_owns_latest_symlink(tmp_path):
+    cfg = {
+        "enable_topk": True,
+        "replace_periodic": True,
+        "save_top_k": 3,
+    }
+    callbacks = _DummyModule(
+        _spec(tmp_path, checkpointer=cfg), monitor="val_acc", mode="max"
+    ).configure_callbacks()
+
+    best = _best_callbacks(callbacks)
+    assert len(best) == 1
+    assert _periodic_callbacks(callbacks) == []
+    assert best[0].monitor == "val_acc"
+    assert best[0].mode == "max"
+    assert best[0].save_top_k == 1
+    assert best[0].save_last == "link"
+    assert best[0].CHECKPOINT_NAME_LAST == "dummy_model_latest"
+    assert best[0]._save_on_train_epoch_end is False
+
+
+def test_config_overrides_network_default(tmp_path):
+    cfg = {"enable_topk": True, "monitor": "val_loss", "mode": "min", "save_top_k": 3}
+    m = _DummyModule(_spec(tmp_path, checkpointer=cfg), monitor="val_acc", mode="max")
+    cb = _best_callbacks(m.configure_callbacks())[0]
+    assert cb.monitor == "val_loss"   # override wins over network default
+    assert cb.mode == "min"
+    assert cb.save_top_k == 3
+
+
+def test_custom_dirpath_respected(tmp_path):
+    sub = tmp_path / "best"
+    cfg = {"enable_topk": True, "dirpath": str(sub)}
+    m = _DummyModule(_spec(tmp_path, checkpointer=cfg))
+    cb = _best_callbacks(m.configure_callbacks())[0]
+    assert str(cb.dirpath) == str(sub)
+
+
+def test_helper_returns_list_when_disabled(tmp_path):
+    # Models that fully override configure_callbacks call
+    #   callbacks = self._configure_best_checkpoint(callbacks, results_dir)
+    # so the helper must return the list (not None) even when the feature is off.
+    m = _DummyModule(_spec(tmp_path))
+    cbs = []
+    out = m._configure_best_checkpoint(cbs, str(tmp_path))
+    assert out is cbs
+    assert _best_callbacks(out) == []
+
+
+def test_helper_returns_list_when_enabled(tmp_path):
+    m = _DummyModule(_spec(tmp_path, checkpointer={"enable_topk": True}),
+                     monitor="val_mAP", mode="max")
+    cbs = []
+    out = m._configure_best_checkpoint(cbs, str(tmp_path))
+    assert out is cbs                       # same list object returned
+    best = _best_callbacks(out)
+    assert len(best) == 1 and best[0].monitor == "val_mAP" and best[0].mode == "max"
+
+
+def test_helper_removes_override_periodic_callback_in_replace_mode(tmp_path):
+    cfg = {"enable_topk": True, "replace_periodic": True}
+    m = _DummyModule(_spec(tmp_path, checkpointer=cfg))
+    periodic = ModelCheckpoint(
+        dirpath=tmp_path,
+        monitor=None,
+        save_top_k=-1,
+        every_n_epochs=1,
+    )
+    callbacks = [periodic]
+
+    out = m._configure_best_checkpoint(callbacks, str(tmp_path))
+
+    assert out is callbacks
+    assert periodic not in out
+    assert _periodic_callbacks(out) == []
+    assert len(_best_callbacks(out)) == 1
+
+
+def test_runtime_guard_raises_on_unlogged_metric():
+    with pytest.raises(ValueError, match="is not logged"):
+        validate_monitor_metric("val_miou", {"val_loss", "val_acc"})
+
+
+def test_runtime_guard_passes_when_present():
+    validate_monitor_metric("val_acc", {"val_loss", "val_acc"})  # no raise
+
+
+def test_config_schema_default_disabled():
+    from omegaconf import OmegaConf
+    from nvidia_tao_pytorch.config.common.common_config import TrainConfig
+    schema = OmegaConf.structured(TrainConfig)
+    assert schema.checkpointer.enable_topk is False
+    assert schema.checkpointer.replace_periodic is False
+    assert schema.checkpointer.monitor is None
+    assert schema.checkpointer.mode is None

--- a/tests/core/test_cuda_device.py
+++ b/tests/core/test_cuda_device.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for rank-local CUDA device binding."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import torch
+
+
+CUDA_DEVICE_MODULE = "nvidia_tao_pytorch.core.utils.cuda_device"
+
+
+def test_cuda_binding_maps_original_rank_zero_to_first_tao_device(monkeypatch):
+    """Import-time binding should map the original process to rank zero."""
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    monkeypatch.setenv("TAO_VISIBLE_DEVICES", "2,5")
+    cudart = MagicMock()
+    cudart.cudaSetDevice.return_value = 0
+
+    with patch("ctypes.CDLL", return_value=cudart):
+        if CUDA_DEVICE_MODULE in sys.modules:
+            importlib.reload(sys.modules[CUDA_DEVICE_MODULE])
+        else:
+            importlib.import_module(CUDA_DEVICE_MODULE)
+
+    cudart.cudaSetDevice.assert_called_once_with(2)
+
+
+def test_cuda_binding_uses_rank_mapped_tao_device(monkeypatch):
+    """A distributed child should bind to its rank-mapped TAO device."""
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    monkeypatch.delenv("TAO_VISIBLE_DEVICES", raising=False)
+    cuda_device = importlib.import_module(CUDA_DEVICE_MODULE)
+
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    monkeypatch.setenv("TAO_VISIBLE_DEVICES", "2,5")
+    cudart = MagicMock()
+    cudart.cudaSetDevice.return_value = 0
+
+    with patch.object(
+        cuda_device.ctypes,
+        "CDLL",
+        return_value=cudart,
+    ) as load_cudart:
+        cuda_device.bind_rank_local_cuda_device()
+
+    cuda_major = torch.version.cuda.split('.', maxsplit=1)[0]
+    load_cudart.assert_called_once_with(f"libcudart.so.{cuda_major}")
+    cudart.cudaSetDevice.assert_called_once_with(5)

--- a/tests/core/test_exception_checkpoint.py
+++ b/tests/core/test_exception_checkpoint.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for exception-time checkpoint behavior."""
+
+from unittest.mock import MagicMock, patch
+
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from nvidia_tao_pytorch.core.callbacks.model_checkpoint import (
+    TAOExceptionCheckpoint,
+)
+
+
+def test_distributed_exception_skips_collective_checkpoint(tmp_path):
+    """A rank-local distributed failure must not enter checkpoint barriers."""
+    callback = TAOExceptionCheckpoint(str(tmp_path))
+    trainer = MagicMock(world_size=8, current_epoch=2, global_step=7)
+
+    with patch.object(ModelCheckpoint, "_link_checkpoint") as link_checkpoint:
+        callback.on_exception(trainer)
+
+    trainer.save_checkpoint.assert_not_called()
+    link_checkpoint.assert_not_called()
+
+
+def test_single_process_exception_still_saves_and_links(tmp_path):
+    """Single-process training should retain the existing recovery checkpoint."""
+    callback = TAOExceptionCheckpoint(str(tmp_path))
+    trainer = MagicMock(world_size=1, current_epoch=2, global_step=7)
+
+    with (
+        patch.object(TAOExceptionCheckpoint, "CHECKPOINT_NAME_LAST", "clip_latest"),
+        patch.object(TAOExceptionCheckpoint, "FILE_EXTENSION", ".pth"),
+        patch.object(ModelCheckpoint, "_link_checkpoint") as link_checkpoint,
+    ):
+        callback.on_exception(trainer)
+
+    expected_checkpoint = str(tmp_path / "model_epoch_002_step_00007.pth")
+    trainer.save_checkpoint.assert_called_once_with(expected_checkpoint)
+    link_checkpoint.assert_called_once_with(
+        trainer,
+        expected_checkpoint,
+        str(tmp_path / "clip_latest.pth"),
+    )

--- a/tests/cv_unit_test/backbone_v2/test_backbone.py
+++ b/tests/cv_unit_test/backbone_v2/test_backbone.py
@@ -15,6 +15,7 @@ from nvidia_tao_pytorch.cv.backbone_v2 import (
     convnext,
     convnext_v2,
     dino_v2,
+    dino_v3,
     efficientvit,
     fan,
     fastervit,
@@ -55,6 +56,18 @@ TEST_TOPOLOGIES = [
         ),
         id="vit_large_patch14_dinov2_swiglu",
     ),
+    # DINOV3.
+    pytest.param(
+        (
+            dino_v3.dinov3_vitb16,
+            "dinov3_base_lvd1689m.safetensors",  # From TIMM.
+            (1, 768),
+            [0.4872, 0.5306, 0.9414, -0.0965, -0.2063],
+        ),
+        id="dinov3_vitb16",
+    ),
+    pytest.param((dino_v3.dinov3_vits16, None, None, None), id="dinov3_vits16"),
+    pytest.param((dino_v3.dinov3_vits16plus, None, None, None), id="dinov3_vits16plus"),
     # EfficientViT.
     pytest.param((efficientvit.efficientvit_b0, None, None, None), id="efficientvit_b0"),
     pytest.param((efficientvit.efficientvit_l0, None, None, None), id="efficientvit_l0"),
@@ -178,6 +191,25 @@ LARGE_BACKBONES = [
     # DINOV2.
     pytest.param(
         (dino_v2.vit_giant_patch14_reg4_dinov2_swiglu, None, None, None), id="vit_giant_patch14_reg4_dinov2_swiglu"
+    ),
+    # DINOV3.
+    pytest.param(
+        (
+            dino_v3.dinov3_vith16plus,
+            "dinov3_huge_plus_lvd1689m.safetensors",  # From TIMM.
+            (1, 1280),
+            [-0.1892, 0.0466, 0.1439, 0.2925, 0.0699],
+        ),
+        id="dinov3_vith16plus",
+    ),
+    pytest.param(
+        (
+            dino_v3.dinov3_vit7b16,
+            None,
+            (1, 4096),
+            None,
+        ),
+        id="dinov3_vit7b16",
     ),
     # RADIO.
     pytest.param(

--- a/tests/cv_unit_test/grounding_dino/test_deterministic_label_order.py
+++ b/tests/cv_unit_test/grounding_dino/test_deterministic_label_order.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for dataset.deterministic_label_order (ODVG caption token-order determinism).
+
+Two complementary tests:
+  1. Flag unit test (in-process): config default is True for grounding_dino and
+     mask_grounding_dino; the serialized ODVG dataset honors the flag, iterates in
+     both modes without error (also a regression guard for the Python 3.11+
+     random.sample(set) crash), and yields only valid label names.
+  2. Determinism test (subprocess): PYTHONHASHSEED is fixed at interpreter startup,
+     so hash-independence can only be exercised across processes. Two subprocesses
+     with PYTHONHASHSEED=0 and =1 dump caption order; with the flag True the order is
+     identical across hash seeds (the guarantee), with it False the order differs
+     (the legacy bug the flag closes).
+"""
+
+import os
+import sys
+import json
+import subprocess
+
+import pytest
+from omegaconf import OmegaConf
+
+
+def _make_synthetic_odvg(tmp_path, n_classes=12, n_images=8):
+    """Write a tiny self-contained ODVG detection dataset (dummy images + jsonl + labelmap).
+
+    n_classes is kept >= 12 so that the hash-seed-dependent set-iteration order is
+    (with overwhelming probability) different from the sorted order and between two
+    PYTHONHASHSEED values.
+    """
+    from PIL import Image
+
+    img_dir = tmp_path / "imgs"
+    img_dir.mkdir()
+    labelmap = {str(i): f"class_{i:02d}" for i in range(n_classes)}
+    (tmp_path / "labelmap.json").write_text(json.dumps(labelmap))
+
+    lines = []
+    for k in range(n_images):
+        Image.new("RGB", (8, 8)).save(img_dir / f"img{k}.jpg")
+        # two positive classes per image -> non-empty neg set -> exercises both
+        # list(pos_labels) order and the negative sampling order.
+        labels = [k % n_classes, (k * 3 + 1) % n_classes]
+        instances = [{"bbox": [0, 0, 4, 4], "label": lb} for lb in labels]
+        lines.append(json.dumps({
+            "file_name": f"img{k}.jpg", "height": 8, "width": 8,
+            "detection": {"instances": instances},
+        }))
+    (tmp_path / "anno.jsonl").write_text("\n".join(lines))
+    return f"{img_dir}/", str(tmp_path / "anno.jsonl"), str(tmp_path / "labelmap.json")
+
+
+# Runs in a fresh interpreter (so PYTHONHASHSEED takes effect). Dumps the first-K
+# captions for both flag values as one JSON line prefixed with RESULT:.
+_HELPER = r"""
+import sys, json
+import torch  # noqa: F401
+from pytorch_lightning import seed_everything
+from nvidia_tao_pytorch.cv.grounding_dino.dataloader.serialized_dataset import (
+    load_coco_jsonl, ODVGSerializedDatasetFromList,
+)
+IMG, ANNO, LMAP, K = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+
+def caps(flag):
+    seed_everything(1234, workers=True)
+    lst = load_coco_jsonl(ANNO, image_root=IMG, labelmap_file=LMAP)
+    ds = ODVGSerializedDatasetFromList(lst, transforms=None, max_labels=80,
+                                       deterministic_label_order=flag)
+    return [ds[i][1]["caption"] for i in range(min(K, len(ds)))]
+
+print("RESULT:" + json.dumps({"true": caps(True), "false": caps(False)}))
+"""
+
+
+def _run_helper(img, anno, lmap, hashseed, k=8):
+    env = dict(os.environ, PYTHONHASHSEED=str(hashseed))
+    proc = subprocess.run(
+        [sys.executable, "-c", _HELPER, img, anno, lmap, str(k)],
+        env=env, capture_output=True, text=True, timeout=600,
+    )
+    assert proc.returncode == 0, f"helper failed (hashseed={hashseed}):\n{proc.stderr[-3000:]}"
+    line = [ln for ln in proc.stdout.splitlines() if ln.startswith("RESULT:")][-1]
+    return json.loads(line[len("RESULT:"):])
+
+
+@pytest.mark.cv_unit
+def test_deterministic_label_order_default_true():
+    """The flag defaults to True on grounding_dino and (inherited) mask_grounding_dino."""
+    from nvidia_tao_pytorch.config.grounding_dino.default_config import ExperimentConfig as GDINOExp
+    from nvidia_tao_pytorch.config.mask_grounding_dino.default_config import ExperimentConfig as MaskExp
+
+    assert OmegaConf.structured(GDINOExp).dataset.deterministic_label_order is True
+    assert OmegaConf.structured(MaskExp).dataset.deterministic_label_order is True
+
+
+@pytest.mark.cv_unit
+def test_dataset_honors_flag(tmp_path):
+    """Dataset stores the flag and iterates in both modes without error (incl. the
+    Python 3.11+ random.sample(set) regression), yielding only valid label names."""
+    from pytorch_lightning import seed_everything
+    from nvidia_tao_pytorch.cv.grounding_dino.dataloader.serialized_dataset import (
+        load_coco_jsonl, ODVGSerializedDatasetFromList,
+    )
+
+    img, anno, lmap = _make_synthetic_odvg(tmp_path)
+    valid = set(json.load(open(lmap)).values())
+
+    for flag in (True, False):
+        seed_everything(1234, workers=True)
+        lst = load_coco_jsonl(anno, image_root=img, labelmap_file=lmap)
+        ds = ODVGSerializedDatasetFromList(lst, transforms=None, max_labels=80,
+                                           deterministic_label_order=flag)
+        assert ds.deterministic_label_order is flag
+        for i in range(min(4, len(ds))):
+            _, target = ds[i]
+            assert set(target["cap_list"]).issubset(valid)
+            assert len(target["cap_list"]) > 0
+
+
+@pytest.mark.cv_unit
+def test_caption_order_hash_independent(tmp_path):
+    """With the flag True, caption order is identical across PYTHONHASHSEED values;
+    with it False, it differs (the legacy non-determinism the flag closes)."""
+    img, anno, lmap = _make_synthetic_odvg(tmp_path)
+    r0 = _run_helper(img, anno, lmap, hashseed=0)
+    r1 = _run_helper(img, anno, lmap, hashseed=1)
+
+    # The guarantee: sorted() canonicalization -> hash-seed independent.
+    assert r0["true"] == r1["true"], "deterministic_label_order=True must be PYTHONHASHSEED-independent"
+    # The bug it closes: legacy set-iteration order flips with the hash seed.
+    assert r0["false"] != r1["false"], "expected legacy (flag off) caption order to vary with PYTHONHASHSEED"

--- a/tests/cv_unit_test/quantization/test_torchao_backend.py
+++ b/tests/cv_unit_test/quantization/test_torchao_backend.py
@@ -36,7 +36,7 @@ def _create_torchao_mocks():
         def __init__(self, module_fqn_to_config):  # noqa: D401 - emulate torchao signature
             self.module_fqn_to_config = module_fqn_to_config
 
-    def _dummy_quantize_(model, cfg):  # noqa: D401 - emulate torchao signature
+    def _dummy_quantize_(model, cfg, **kwargs):  # noqa: D401 - emulate torchao signature
         # In-place no-op; return the model
         return model
 

--- a/tests/cv_unit_test/quantization/test_utils.py
+++ b/tests/cv_unit_test/quantization/test_utils.py
@@ -6,6 +6,7 @@
 import pytest
 import torch
 import torch.nn as nn
+import sys
 from unittest.mock import Mock, patch
 
 from nvidia_tao_pytorch.core.quantization.utils import match_layer, create_quantized_model_from_config
@@ -159,6 +160,17 @@ class DummyLightning(nn.Module):
 
     def load_state_dict(self, state_dict):
         self.loaded_state_dict = state_dict
+
+
+class DummyWrappedLightning(nn.Module):
+    def __init__(self, experiment_config, **kwargs):
+        super().__init__()
+        self.experiment_config = experiment_config
+        self.kwargs = kwargs
+        self.model = nn.Linear(10, 1)
+
+    def forward(self, x):
+        return self.model(x)
 
 
 class MockConfig:
@@ -343,6 +355,90 @@ def test_create_quantized_model_from_config_modelopt_backend(mock_quantizer_clas
         # Verify ModelQuantizer was called correctly
         mock_quantizer_class.assert_called_once_with(exp_cfg.quantize)
         mock_quantizer.quantize_model.assert_called_once()
+
+
+@patch('nvidia_tao_pytorch.core.quantization.quantizer.ModelQuantizer')
+def test_create_quantized_model_from_config_modelopt_restore(mock_quantizer_class, tmp_path, mock_all_backend_dependencies):
+    """Test ModelOpt checkpoints are restored with modelopt_state metadata."""
+    exp_cfg = make_experiment_config(backend="modelopt.pytorch")
+    ckpt_path = tmp_path / "modelopt_model.pth"
+    restored_model = nn.Linear(10, 1)
+    mock_modelopt = Mock()
+    mock_torch = Mock()
+    mock_mto = Mock()
+    mock_modelopt.torch = mock_torch
+    mock_torch.opt = mock_mto
+    mock_mto.restore.return_value = restored_model
+
+    with patch('torch.load') as mock_load, patch.dict(
+        sys.modules,
+        {
+            'modelopt': mock_modelopt,
+            'modelopt.torch': mock_torch,
+            'modelopt.torch.opt': mock_mto,
+        },
+        clear=False,
+    ):
+        mock_load.return_value = {
+            "modelopt_state": {"enabled": True},
+            "model_state_dict": {"weight": torch.tensor(42)},
+        }
+
+        model = create_quantized_model_from_config(
+            str(ckpt_path),
+            DummyWrappedLightning,
+            experiment_config=exp_cfg
+        )
+
+    assert isinstance(model, DummyWrappedLightning), f"Expected DummyWrappedLightning, got {type(model).__name__}"
+    assert model.model is restored_model, "Wrapped network should be restored with ModelOpt state"
+    mock_mto.restore.assert_called_once()
+    restore_args, restore_kwargs = mock_mto.restore.call_args
+    assert isinstance(restore_args[0], nn.Linear), "ModelOpt restore should target the wrapped nn.Module"
+    assert restore_args[1] == str(ckpt_path)
+    assert restore_kwargs["map_location"] == "cpu"
+    mock_quantizer_class.assert_not_called()
+
+
+@patch('nvidia_tao_pytorch.core.quantization.quantizer.ModelQuantizer')
+def test_create_quantized_model_from_config_modelopt_restore_from_checkpoint_metadata(
+    mock_quantizer_class, tmp_path, mock_all_backend_dependencies
+):
+    """ModelOpt checkpoint metadata should override a stale torchao eval spec."""
+    exp_cfg = make_experiment_config(backend="torchao")
+    ckpt_path = tmp_path / "modelopt_model.pth"
+    restored_model = nn.Linear(10, 1)
+    mock_modelopt = Mock()
+    mock_torch = Mock()
+    mock_mto = Mock()
+    mock_modelopt.torch = mock_torch
+    mock_torch.opt = mock_mto
+    mock_mto.restore.return_value = restored_model
+
+    with patch('torch.load') as mock_load, patch.dict(
+        sys.modules,
+        {
+            'modelopt': mock_modelopt,
+            'modelopt.torch': mock_torch,
+            'modelopt.torch.opt': mock_mto,
+        },
+        clear=False,
+    ):
+        mock_load.return_value = {
+            "modelopt_state": {"enabled": True},
+            "model_state_dict": {"weight": torch.tensor(42)},
+        }
+
+        model = create_quantized_model_from_config(
+            str(ckpt_path),
+            DummyWrappedLightning,
+            experiment_config=exp_cfg
+        )
+
+    assert isinstance(model, DummyWrappedLightning), f"Expected DummyWrappedLightning, got {type(model).__name__}"
+    assert model.model is restored_model, "ModelOpt metadata should restore the wrapped nn.Module"
+    mock_mto.restore.assert_called_once()
+    mock_quantizer_class.assert_not_called()
 
 
 @patch('nvidia_tao_pytorch.core.quantization.quantizer.ModelQuantizer')

--- a/tests/cv_unit_test/visual_changenet/test_epoch_end_logging.py
+++ b/tests/cv_unit_test/visual_changenet/test_epoch_end_logging.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Visual ChangeNet epoch-end status logging."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.cv.visual_changenet.classification.models import cn_pl_model as classify_module
+from nvidia_tao_pytorch.cv.visual_changenet.segmentation.models import cn_pl_model as segment_module
+
+
+@pytest.mark.cv_unit
+@pytest.mark.parametrize(
+    ("model_module", "epoch_end_hook"),
+    (
+        (
+            classify_module,
+            classify_module.ChangeNetPlModel.on_train_epoch_end,
+        ),
+        (
+            segment_module,
+            segment_module.ChangeNetPlModel.on_train_epoch_end,
+        ),
+    ),
+)
+def test_train_epoch_end_skips_replayed_hook_without_train_loss(
+    monkeypatch, model_module, epoch_end_hook
+):
+    """A validation-checkpoint resume may replay the hook before new batches."""
+    get_status_logger = MagicMock()
+    monkeypatch.setattr(
+        model_module.status_logging,
+        "get_status_logger",
+        get_status_logger,
+    )
+    train_metrics = MagicMock()
+    model = SimpleNamespace(
+        trainer=SimpleNamespace(logged_metrics={"val_loss": torch.tensor(0.5)}),
+        train_metrics=train_metrics,
+        status_logging_dict={"existing": "value"},
+        visualize_histogram=MagicMock(),
+        visualize_metrics=MagicMock(),
+    )
+
+    epoch_end_hook(model)
+
+    assert model.status_logging_dict == {"existing": "value"}
+    train_metrics.compute.assert_not_called()
+    train_metrics.reset.assert_not_called()
+    model.visualize_histogram.assert_not_called()
+    model.visualize_metrics.assert_not_called()
+    get_status_logger.assert_not_called()
+
+
+@pytest.mark.cv_unit
+def test_classification_train_epoch_end_preserves_normal_logging(monkeypatch):
+    """Classification still aggregates and publishes a completed epoch."""
+    status_logger = MagicMock()
+    monkeypatch.setattr(
+        classify_module.status_logging,
+        "get_status_logger",
+        MagicMock(return_value=status_logger),
+    )
+    train_metrics = MagicMock()
+    train_metrics.compute.return_value = {
+        "total_accuracy": torch.tensor(80.0),
+        "false_alarm": torch.tensor(5.0),
+    }
+    model = SimpleNamespace(
+        trainer=SimpleNamespace(
+            logged_metrics={"train_loss_epoch": torch.tensor(0.25)}
+        ),
+        train_metrics=train_metrics,
+        status_logging_dict={},
+        tensorboard=SimpleNamespace(infrequent_logging_frequency=2),
+        visualize_histogram=MagicMock(),
+        visualize_metrics=MagicMock(),
+    )
+
+    classify_module.ChangeNetPlModel.on_train_epoch_end(model)
+
+    assert model.status_logging_dict == {
+        "train_loss": pytest.approx(0.25),
+        "train_acc": pytest.approx(80.0),
+        "train_fpr": pytest.approx(5.0),
+    }
+    model.visualize_histogram.assert_called_once_with(logging_frequency=2)
+    model.visualize_metrics.assert_called_once_with({
+        "train_acc": pytest.approx(80.0),
+        "train_fpr": pytest.approx(5.0),
+    })
+    train_metrics.reset.assert_called_once_with()
+    assert status_logger.kpi == model.status_logging_dict
+    status_logger.write.assert_called_once_with(
+        message="Train metrics generated.",
+        status_level=classify_module.status_logging.Status.RUNNING,
+    )
+
+
+@pytest.mark.cv_unit
+def test_segmentation_train_epoch_end_preserves_normal_logging(monkeypatch):
+    """Segmentation still publishes loss for a completed training epoch."""
+    status_logger = MagicMock()
+    monkeypatch.setattr(
+        segment_module.status_logging,
+        "get_status_logger",
+        MagicMock(return_value=status_logger),
+    )
+    model = SimpleNamespace(
+        trainer=SimpleNamespace(
+            logged_metrics={"train_loss_epoch": torch.tensor(0.0)}
+        ),
+        status_logging_dict={},
+    )
+
+    segment_module.ChangeNetPlModel.on_train_epoch_end(model)
+
+    assert model.status_logging_dict == {"train_loss": pytest.approx(0.0)}
+    assert status_logger.kpi == model.status_logging_dict
+    status_logger.write.assert_called_once_with(
+        message="Train metrics generated.",
+        status_level=segment_module.status_logging.Status.RUNNING,
+    )

--- a/tests/cv_unit_test/visual_changenet/test_legacy_config_backbone_parity.py
+++ b/tests/cv_unit_test/visual_changenet/test_legacy_config_backbone_parity.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parity guard for the legacy visual_changenet config duplicate (bug 6465432).
+
+nvidia_tao_pytorch/cv/visual_changenet/config/default_config.py is a legacy
+duplicate that the TAO-1950 rewire orphaned (the training scripts import the
+canonical nvidia_tao_pytorch/config/visual_changenet/default_config instead).
+It is kept in sync for consistency; this asserts its backbone type options do
+not drift from the canonical config again - which is how it fell behind the
+DINOv3 backbones in the 7.1.0 report.
+"""
+from dataclasses import fields
+
+from nvidia_tao_pytorch.config.visual_changenet.default_config import (
+    BackboneConfig as CanonicalBackboneConfig,
+)
+from nvidia_tao_pytorch.cv.visual_changenet.config.default_config import (
+    BackboneConfig as LegacyBackboneConfig,
+)
+
+DINOV3_DOWNSTREAM_BACKBONES = [
+    "vit_small_dinov3",
+    "vit_small_plus_dinov3",
+    "vit_base_dinov3",
+    "vit_large_dinov3",
+    "vit_huge_plus_dinov3",
+]
+
+
+def _type_options(backbone_config_cls):
+    """Return the backbone ``type`` field's raw valid_options string."""
+    (type_field,) = [f for f in fields(backbone_config_cls) if f.name == "type"]
+    return type_field.metadata["valid_options"]
+
+
+def test_legacy_backbone_options_match_canonical():
+    assert _type_options(LegacyBackboneConfig) == _type_options(CanonicalBackboneConfig)
+
+
+def test_legacy_backbone_has_dinov3():
+    options = _type_options(LegacyBackboneConfig).split(",")
+    missing = [b for b in DINOV3_DOWNSTREAM_BACKBONES if b not in options]
+    assert not missing, f"legacy config backbone enum missing DINOv3 options: {missing}"

--- a/tests/cv_unit_test/visual_changenet/test_model.py
+++ b/tests/cv_unit_test/visual_changenet/test_model.py
@@ -25,6 +25,8 @@ TEST_TOPOLOGIES = [
     ("vit_large_nvdinov2"),
     ("c_radio_p3_vit_huge_patch16_224_mlpnorm"),
     ("c_radio_v2_vit_base_patch16_224"),
+    ("vit_small_dinov3"),
+    ("vit_small_plus_dinov3"),
 ]
 TEST_TOPOLOGIES_CLASSIFICATION_PTM = [
     # classification_pyt, visual_changenet

--- a/tests/multimodal_unit_test/clip/test_dataloader.py
+++ b/tests/multimodal_unit_test/clip/test_dataloader.py
@@ -3,16 +3,27 @@
 
 """Unit tests for CLIP custom dataloader."""
 
+import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
 from PIL import Image
 
+import nvidia_tao_pytorch.multimodal.clip.dataloader.custom_loader as custom_loader
+import nvidia_tao_pytorch.multimodal.clip.dataloader.pl_clip_data_module as clip_data_module
+from nvidia_tao_pytorch.multimodal.clip.dataloader.pl_clip_data_module import (
+    CLIPDataModule,
+)
 from nvidia_tao_pytorch.multimodal.clip.dataloader.custom_loader import (
     ImageTextDataset,
     get_custom_dataloader,
+)
+from nvidia_tao_pytorch.multimodal.clip.dataloader.sampler import (
+    BalancedByQueryTypeSampler,
+    BalancedUniqueCaptionBatchSampler,
 )
 
 
@@ -48,6 +59,105 @@ def temp_dataset():
             'image_dir_path': image_dir,
             'caption_dir_path': label_dir,
         }
+
+
+def _make_attribute_pair(idx, width=7, query_type="easy"):
+    """Build one split-pairs metadata row with scalar attribute vectors."""
+    return {
+        "query_type": query_type,
+        "caption": f"Caption for image {idx}",
+        "unique_name": f"image_{idx}.jpg",
+        "image_attr_values": list(range(idx, idx + width)),
+        "text_attr_values": [idx] + [-1] + list(range(idx + 2, idx + width)),
+    }
+
+
+def _write_attribute_pairs(path, count, width=7):
+    """Write count aligned metadata rows to a pairs JSON file."""
+    rows = [
+        _make_attribute_pair(
+            idx=i,
+            width=width,
+            query_type="easy" if i % 2 == 0 else "medium",
+        )
+        for i in range(count)
+    ]
+    path.write_text(json.dumps(rows))
+    return rows
+
+
+def _write_accessory_vocab(path):
+    """Write a small accessory vocabulary with zero reserved for padding."""
+    path.write_text(json.dumps({
+        "unknown_id": 0,
+        "value_to_id": {
+            "__unknown__": 0,
+            "black backpack": 11,
+            "red hat": 12,
+        },
+    }))
+
+
+def _write_attribute_vocab(
+    path,
+    attributes,
+    value_to_id,
+    indent=None,
+):
+    """Write an ordered scalar-attribute vocabulary."""
+    path.write_text(json.dumps(
+        {
+            "attributes": attributes,
+            "value_to_id": value_to_id,
+        },
+        indent=indent,
+    ))
+
+
+def _attribute_dataset_config(temp_dataset, pairs_file):
+    """Build one custom dataset config with scalar metadata."""
+    return {
+        'image_dir': temp_dataset['image_dir'],
+        'caption_dir': temp_dataset['caption_dir'],
+        'image_list_file': temp_dataset['image_list_file'],
+        'caption_file_suffix': '.txt',
+        'train_pairs_file': str(pairs_file),
+    }
+
+
+def _validation_attribute_dataset_config(temp_dataset, pairs_file):
+    """Build one validation dataset config with scalar metadata."""
+    config = _attribute_dataset_config(temp_dataset, pairs_file)
+    config.pop("train_pairs_file")
+    config["attribute_pairs_file"] = str(pairs_file)
+    return config
+
+
+def _write_attribute_source(
+    tmp_path,
+    name,
+    attributes,
+    value_to_id,
+    write_vocab=True,
+    indent=None,
+):
+    """Write one pairs/vocabulary source for multi-dataset tests."""
+    source_dir = tmp_path / name
+    source_dir.mkdir()
+    pairs_file = source_dir / "train_pairs.json"
+    _write_attribute_pairs(
+        pairs_file,
+        count=5,
+        width=len(attributes),
+    )
+    if write_vocab:
+        _write_attribute_vocab(
+            source_dir / "attribute_vocab.json",
+            attributes,
+            value_to_id,
+            indent=indent,
+        )
+    return pairs_file
 
 
 @pytest.mark.multimodal_unit
@@ -244,6 +354,564 @@ class TestImageTextDataset:
 
         assert len(dataset) == 5
 
+    def test_attribute_metadata_returns_third_item(self, temp_dataset):
+        """Test optional attribute metadata is returned with a sample."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = _write_attribute_pairs(pairs_file, count=5, width=7)
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        dataset = ImageTextDataset(
+            datasets=dataset_config,
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        image, text, metadata = dataset[0]
+
+        assert isinstance(image, Image.Image)
+        assert "Caption for image" in text
+        assert set(metadata) == {"image_attr_values", "text_attr_values"}
+        assert metadata["image_attr_values"].dtype == torch.long
+        assert metadata["text_attr_values"].dtype == torch.long
+        assert metadata["image_attr_values"].shape == (7,)
+        assert metadata["text_attr_values"].shape == (7,)
+        assert metadata["text_attr_values"].tolist() == rows[0]["text_attr_values"]
+        assert metadata["text_attr_values"][1].item() == -1
+
+    def test_attribute_metadata_warns_without_vocab(
+        self, temp_dataset, monkeypatch
+    ):
+        """Test missing normalization vocabulary is surfaced to users."""
+        warnings = []
+        monkeypatch.setattr(
+            custom_loader.logging,
+            "warning",
+            lambda *args: warnings.append(args),
+        )
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        _write_attribute_pairs(pairs_file, count=5, width=7)
+
+        ImageTextDataset(
+            datasets=[_attribute_dataset_config(temp_dataset, pairs_file)],
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        assert len(warnings) == 1
+        message, warned_pairs_file, warned_vocab_path = warnings[0]
+        assert "not visible" in message
+        assert warned_pairs_file == pairs_file
+        assert warned_vocab_path == (
+            temp_dataset['tmpdir'] / "attribute_vocab.json"
+        )
+
+    def test_attribute_metadata_includes_padded_accessory_ids(self, temp_dataset):
+        """Test accessory lists are padded and returned with scalars."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = _write_attribute_pairs(pairs_file, count=5, width=7)
+        image_accessories = [[11, 12], [11], [], [12], [11, 12]]
+        text_accessories = [[11], [], [], [12], [11, 12]]
+        for row, image_ids, text_ids in zip(
+            rows, image_accessories, text_accessories
+        ):
+            row["image_accessory_ids"] = image_ids
+            row["text_accessory_ids"] = text_ids
+        pairs_file.write_text(json.dumps(rows))
+        _write_accessory_vocab(temp_dataset['tmpdir'] / "accessory_vocab.json")
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        dataset = ImageTextDataset(
+            datasets=dataset_config,
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        _, _, first = dataset[0]
+        _, _, second = dataset[1]
+        assert set(first) == {
+            "image_attr_values",
+            "text_attr_values",
+            "image_accessory_ids",
+            "text_accessory_ids",
+        }
+        assert first["image_accessory_ids"].tolist() == [11, 12]
+        assert first["text_accessory_ids"].tolist() == [11, 0]
+        assert second["image_accessory_ids"].tolist() == [11, 0]
+
+    def test_accessory_metadata_requires_paired_subset(self, temp_dataset):
+        """Test a query cannot require an accessory absent from its image."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = _write_attribute_pairs(pairs_file, count=5, width=7)
+        for row in rows:
+            row["image_accessory_ids"] = [11]
+            row["text_accessory_ids"] = [11]
+        rows[0]["text_accessory_ids"] = [12]
+        pairs_file.write_text(json.dumps(rows))
+        _write_accessory_vocab(temp_dataset['tmpdir'] / "accessory_vocab.json")
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        with pytest.raises(ValueError, match="not contained"):
+            ImageTextDataset(
+                datasets=dataset_config,
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_attribute_metadata_treats_not_visible_as_missing(self, temp_dataset):
+        """Test not-visible vocab IDs are normalized to wildcard values."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = _write_attribute_pairs(pairs_file, count=5, width=2)
+        rows[0]["image_attr_values"] = [8, 5]
+        rows[0]["text_attr_values"] = [8, 5]
+        pairs_file.write_text(json.dumps(rows))
+        vocab = {
+            "attributes": ["top outer color", "top outer type"],
+            "value_to_id": {
+                "top outer color": {
+                    "__missing__": 0,
+                    "black": 2,
+                    "not visible": 8,
+                },
+                "top outer type": {
+                    "__missing__": 0,
+                    "not visible": 5,
+                    "t shirt": 9,
+                },
+            },
+        }
+        (temp_dataset['tmpdir'] / "attribute_vocab.json").write_text(
+            json.dumps(vocab)
+        )
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        dataset = ImageTextDataset(
+            datasets=dataset_config,
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        _, _, metadata = dataset[0]
+        assert metadata["image_attr_values"].tolist() == [-1, -1]
+        assert metadata["text_attr_values"].tolist() == [-1, -1]
+
+    def test_attribute_metadata_missing_field_raises(self, temp_dataset):
+        """Test missing attribute metadata fields fail clearly."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = [_make_attribute_pair(i) for i in range(5)]
+        rows[0].pop("text_attr_values")
+        pairs_file.write_text(json.dumps(rows))
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        with pytest.raises(ValueError, match="missing 'text_attr_values'"):
+            ImageTextDataset(
+                datasets=dataset_config,
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_attribute_metadata_mismatched_length_raises(self, temp_dataset):
+        """Test pairs/list length mismatch fails when metadata is requested."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        _write_attribute_pairs(pairs_file, count=4, width=7)
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        with pytest.raises(ValueError, match="has 4 items but image list has 5"):
+            ImageTextDataset(
+                datasets=dataset_config,
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_attribute_metadata_infers_val_pairs_file(self, temp_dataset):
+        """Test validation infers val_pairs.json from val_list.txt."""
+        val_list_file = temp_dataset['tmpdir'] / "val_list.txt"
+        val_list_file.write_text(
+            "\n".join([f"image_{i}.jpg" for i in range(5)])
+        )
+        val_pairs_file = temp_dataset['tmpdir'] / "val_pairs.json"
+        _write_attribute_pairs(val_pairs_file, count=5, width=7)
+        _write_attribute_vocab(
+            temp_dataset['tmpdir'] / "attribute_vocab.json",
+            attributes=[f"attribute_{i}" for i in range(7)],
+            value_to_id={},
+        )
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': str(val_list_file),
+            'caption_file_suffix': '.txt',
+        }]
+
+        dataset = ImageTextDataset(
+            datasets=dataset_config,
+            mode='val',
+            include_attribute_metadata=True,
+        )
+
+        _, _, metadata = dataset[0]
+        assert metadata["image_attr_values"].shape == (7,)
+        assert metadata["text_attr_values"].shape == (7,)
+        assert metadata["pas_row_index"].item() == 0
+
+    def test_validation_attribute_metadata_rejects_reordered_pairs(
+        self, temp_dataset
+    ):
+        """Test equal-length validation metadata cannot change row order."""
+        pairs_file = temp_dataset['tmpdir'] / "val_pairs.json"
+        rows = _write_attribute_pairs(pairs_file, count=5, width=7)
+        rows[0], rows[1] = rows[1], rows[0]
+        pairs_file.write_text(json.dumps(rows))
+
+        with pytest.raises(
+            ValueError,
+            match="unique_name .* does not match image list entry",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _validation_attribute_dataset_config(
+                        temp_dataset,
+                        pairs_file,
+                    )
+                ],
+                mode='val',
+                include_attribute_metadata=True,
+            )
+
+    def test_validation_attribute_metadata_rejects_stale_caption(
+        self, temp_dataset
+    ):
+        """Test validation JSON captions must match caption-file contents."""
+        pairs_file = temp_dataset['tmpdir'] / "val_pairs.json"
+        _write_attribute_pairs(pairs_file, count=5, width=7)
+        (
+            temp_dataset['caption_dir_path'] / "image_0.txt"
+        ).write_text("Stale caption")
+
+        with pytest.raises(
+            ValueError,
+            match="caption .* does not match caption file",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _validation_attribute_dataset_config(
+                        temp_dataset,
+                        pairs_file,
+                    )
+                ],
+                mode='val',
+                include_attribute_metadata=True,
+            )
+
+    def test_attribute_metadata_inconsistent_width_raises(self, temp_dataset):
+        """Test inconsistent attribute vector widths fail clearly."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = [_make_attribute_pair(i, width=7) for i in range(5)]
+        rows[1]["text_attr_values"].append(99)
+        pairs_file.write_text(json.dumps(rows))
+        dataset_config = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        with pytest.raises(ValueError, match="expected 7"):
+            ImageTextDataset(
+                datasets=dataset_config,
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    @pytest.mark.parametrize("invalid_id", [1.9, "2", True])
+    def test_attribute_metadata_rejects_non_integer_ids(
+        self, temp_dataset, invalid_id
+    ):
+        """Test scalar attribute IDs are not silently coerced to integers."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        rows = [_make_attribute_pair(i, width=2) for i in range(5)]
+        rows[0]["image_attr_values"][0] = invalid_id
+        pairs_file.write_text(json.dumps(rows))
+
+        with pytest.raises(ValueError, match="must contain integers"):
+            ImageTextDataset(
+                datasets=[
+                    _attribute_dataset_config(temp_dataset, pairs_file)
+                ],
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_multi_dataset_attribute_metadata_accepts_matching_vocabularies(
+        self, temp_dataset, tmp_path
+    ):
+        """Test equivalent ordered vocabularies can share one training set."""
+        attributes = ["upper color", "lower color"]
+        value_to_id = {
+            "upper color": {"__missing__": 0, "black": 1},
+            "lower color": {"__missing__": 0, "blue": 2},
+        }
+        first_pairs = _write_attribute_source(
+            tmp_path,
+            "first",
+            attributes,
+            value_to_id,
+        )
+        second_pairs = _write_attribute_source(
+            tmp_path,
+            "second",
+            attributes,
+            dict(reversed(list(value_to_id.items()))),
+            indent=2,
+        )
+
+        dataset = ImageTextDataset(
+            datasets=[
+                _attribute_dataset_config(temp_dataset, first_pairs),
+                _attribute_dataset_config(temp_dataset, second_pairs),
+            ],
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        assert len(dataset) == 10
+
+    def test_multi_dataset_val_metadata_uses_global_row_indices(
+        self, temp_dataset, tmp_path
+    ):
+        """Test matching vocabularies preserve concatenated validation order."""
+        attributes = ["upper color", "lower color"]
+        value_to_id = {
+            "upper color": {"__missing__": 0, "black": 1},
+            "lower color": {"__missing__": 0, "blue": 2},
+        }
+        first_pairs = _write_attribute_source(
+            tmp_path,
+            "first",
+            attributes,
+            value_to_id,
+        )
+        second_pairs = _write_attribute_source(
+            tmp_path,
+            "second",
+            attributes,
+            dict(reversed(list(value_to_id.items()))),
+            indent=2,
+        )
+
+        dataset = ImageTextDataset(
+            datasets=[
+                _validation_attribute_dataset_config(
+                    temp_dataset, first_pairs
+                ),
+                _validation_attribute_dataset_config(
+                    temp_dataset, second_pairs
+                ),
+            ],
+            mode='val',
+            include_attribute_metadata=True,
+        )
+
+        assert len(dataset) == 10
+        assert dataset[0][2]["pas_row_index"].item() == 0
+        assert dataset[5][2]["pas_row_index"].item() == 5
+        assert dataset[9][2]["pas_row_index"].item() == 9
+
+    def test_multi_dataset_attribute_metadata_requires_each_vocab(
+        self, temp_dataset, tmp_path
+    ):
+        """Test every scalar metadata source provides its vocabulary."""
+        attributes = ["upper color", "lower color"]
+        value_to_id = {
+            "upper color": {"__missing__": 0, "black": 1},
+            "lower color": {"__missing__": 0, "blue": 2},
+        }
+        first_pairs = _write_attribute_source(
+            tmp_path,
+            "first",
+            attributes,
+            value_to_id,
+        )
+        second_pairs = _write_attribute_source(
+            tmp_path,
+            "second",
+            attributes,
+            value_to_id,
+            write_vocab=False,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="Multi-dataset attribute metadata requires",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _attribute_dataset_config(temp_dataset, first_pairs),
+                    _attribute_dataset_config(temp_dataset, second_pairs),
+                ],
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_multi_dataset_attribute_metadata_rejects_reordered_vocab(
+        self, temp_dataset, tmp_path
+    ):
+        """Test equal-width sources cannot change attribute column order."""
+        attributes = ["upper color", "lower color"]
+        value_to_id = {
+            "upper color": {"__missing__": 0, "black": 1},
+            "lower color": {"__missing__": 0, "blue": 2},
+        }
+        first_pairs = _write_attribute_source(
+            tmp_path,
+            "first",
+            attributes,
+            value_to_id,
+        )
+        second_pairs = _write_attribute_source(
+            tmp_path,
+            "second",
+            list(reversed(attributes)),
+            value_to_id,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="same ordered attribute vocabulary",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _attribute_dataset_config(temp_dataset, first_pairs),
+                    _attribute_dataset_config(temp_dataset, second_pairs),
+                ],
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_multi_dataset_attribute_metadata_rejects_different_ids(
+        self, temp_dataset, tmp_path
+    ):
+        """Test equal attribute order cannot use different value IDs."""
+        attributes = ["upper color", "lower color"]
+        first_pairs = _write_attribute_source(
+            tmp_path,
+            "first",
+            attributes,
+            {
+                "upper color": {"__missing__": 0, "black": 1},
+                "lower color": {"__missing__": 0, "blue": 2},
+            },
+        )
+        second_pairs = _write_attribute_source(
+            tmp_path,
+            "second",
+            attributes,
+            {
+                "upper color": {"__missing__": 0, "black": 3},
+                "lower color": {"__missing__": 0, "blue": 2},
+            },
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="same ordered attribute vocabulary",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _attribute_dataset_config(temp_dataset, first_pairs),
+                    _attribute_dataset_config(temp_dataset, second_pairs),
+                ],
+                mode='train',
+                include_attribute_metadata=True,
+            )
+
+    def test_multi_dataset_val_metadata_rejects_different_accessory_vocab_json(
+        self, temp_dataset, tmp_path
+    ):
+        """Test validation requires identical accessory vocabulary JSON."""
+        attributes = ["upper color", "lower color"]
+        value_to_id = {
+            "upper color": {"__missing__": 0, "black": 1},
+            "lower color": {"__missing__": 0, "blue": 2},
+        }
+        pair_files = [
+            _write_attribute_source(
+                tmp_path,
+                name,
+                attributes,
+                value_to_id,
+            )
+            for name in ("first", "second")
+        ]
+        for source_index, pairs_file in enumerate(pair_files):
+            rows = json.loads(pairs_file.read_text())
+            for row in rows:
+                row["image_accessory_ids"] = [11]
+                row["text_accessory_ids"] = [11]
+            pairs_file.write_text(json.dumps(rows))
+            accessory_vocab = {
+                "unknown_id": 0,
+                "value_to_id": {
+                    "__unknown__": 0,
+                    "black backpack": 11,
+                },
+                "source": source_index,
+            }
+            (pairs_file.parent / "accessory_vocab.json").write_text(
+                json.dumps(accessory_vocab)
+            )
+
+        with pytest.raises(
+            ValueError,
+            match="same accessory vocabulary",
+        ):
+            ImageTextDataset(
+                datasets=[
+                    _validation_attribute_dataset_config(
+                        temp_dataset, pairs_file
+                    )
+                    for pairs_file in pair_files
+                ],
+                mode='val',
+                include_attribute_metadata=True,
+            )
+
 
 @pytest.mark.multimodal_unit
 class TestGetCustomDataloader:
@@ -375,3 +1043,322 @@ class TestGetCustomDataloader:
         images, texts = next(iter(dataloader))
         assert images.shape == (2, 3, 32, 32)
         assert texts.shape == (2, 3)
+
+    def test_balanced_query_type_sampler_validates_metadata_length(self):
+        """Test that balanced sampler raises a useful error for bad metadata."""
+        with pytest.raises(ValueError, match="must match num_samples"):
+            BalancedByQueryTypeSampler(
+                num_samples=3,
+                query_type_per_index=["easy", "hard"],
+            )
+
+    def test_balanced_query_type_sampler_uses_set_epoch(self):
+        """Test that set_epoch changes rank partitioning deterministically."""
+        sampler = BalancedByQueryTypeSampler(
+            num_samples=10,
+            query_type_per_index=["easy"] * 5 + ["hard"] * 5,
+            num_replicas=2,
+            rank=0,
+            seed=7,
+        )
+
+        epoch0_indices = sampler._rank_indices()
+        sampler.set_epoch(1)
+        epoch1_indices = sampler._rank_indices()
+
+        assert epoch0_indices != epoch1_indices
+        assert sampler.epoch == 1
+
+    def test_unique_caption_batch_sampler_keeps_epoch_external(self):
+        """Test unique-caption batches and external epoch control."""
+        sampler = BalancedUniqueCaptionBatchSampler(
+            num_samples=4,
+            query_type_per_index=["easy", "easy", "hard", "hard"],
+            caption_per_index=["same", "easy-only", "same", "hard-only"],
+            batch_size=2,
+            seed=13,
+            query_types_order=("easy", "hard"),
+        )
+
+        sampler.set_epoch(3)
+        batches = list(sampler)
+
+        assert sampler.epoch == 3
+        assert batches
+        for batch in batches:
+            captions = [
+                sampler.caption_per_index[idx]
+                for idx in batch
+            ]
+            query_types = {
+                sampler.query_type_per_index[idx]
+                for idx in batch
+            }
+            assert len(batch) == 2
+            assert len(captions) == len(set(captions))
+            assert query_types == {"easy", "hard"}
+
+    def test_balanced_metadata_reads_each_dataset_train_pairs_file(
+        self, temp_dataset, tmp_path
+    ):
+        """Test per-dataset train_pairs_file handling for multi-dataset training."""
+        second_image_dir = tmp_path / "images_2"
+        second_caption_dir = tmp_path / "labels_2"
+        second_image_dir.mkdir()
+        second_caption_dir.mkdir()
+        for i in range(2):
+            image_name = f"second_{i}.jpg"
+            Image.new("RGB", (32, 32)).save(second_image_dir / image_name)
+            (second_caption_dir / f"second_{i}.txt").write_text(
+                f"Second caption {i}"
+            )
+
+        second_image_list = tmp_path / "second_list.txt"
+        second_image_list.write_text("second_0.jpg\nsecond_1.jpg\n")
+
+        first_pairs_file = tmp_path / "first_pairs.json"
+        first_pairs_file.write_text(json.dumps([
+            {
+                "query_type": "easy" if i % 2 == 0 else "hard",
+                "caption": f"Caption for image {i}",
+            }
+            for i in range(5)
+        ]))
+        second_pairs_file = tmp_path / "second_pairs.json"
+        second_pairs_file.write_text(json.dumps([
+            {"query_type": "medium", "caption": "Second caption 0"},
+            {"query_type": "hard", "caption": "Second caption 1"},
+        ]))
+
+        dataset_configs = [
+            {
+                "image_dir": temp_dataset["image_dir"],
+                "caption_dir": temp_dataset["caption_dir"],
+                "image_list_file": temp_dataset["image_list_file"],
+                "caption_file_suffix": ".txt",
+                "train_pairs_file": str(first_pairs_file),
+            },
+            {
+                "image_dir": str(second_image_dir),
+                "caption_dir": str(second_caption_dir),
+                "image_list_file": str(second_image_list),
+                "caption_file_suffix": ".txt",
+                "train_pairs_file": str(second_pairs_file),
+            },
+        ]
+
+        dataloader = get_custom_dataloader(
+            datasets=dataset_configs,
+            batch_size=2,
+            num_workers=0,
+            mode="train",
+            balance_query_types=True,
+            unique_caption_per_batch=False,
+        )
+
+        sampler = dataloader.batch_sampler.sampler
+        assert isinstance(sampler, BalancedByQueryTypeSampler)
+        assert sampler.num_samples == 7
+        assert len(sampler.query_type_per_index) == 7
+
+    def test_attribute_metadata_collates_to_batch_tensors(self, temp_dataset):
+        """Test DataLoader collates optional attribute metadata to [B, A]."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        _write_attribute_pairs(pairs_file, count=5, width=7)
+        dataset_configs = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        def dummy_transform(img):
+            return torch.zeros(3, 32, 32)
+
+        dataloader = get_custom_dataloader(
+            datasets=dataset_configs,
+            batch_size=2,
+            transform=dummy_transform,
+            num_workers=0,
+            mode='train',
+            include_attribute_metadata=True,
+        )
+
+        images, texts, metadata = next(iter(dataloader))
+
+        assert images.shape == (2, 3, 32, 32)
+        assert len(texts) == 2
+        assert metadata["image_attr_values"].shape == (2, 7)
+        assert metadata["text_attr_values"].shape == (2, 7)
+        assert metadata["image_attr_values"].dtype == torch.long
+        assert metadata["text_attr_values"].dtype == torch.long
+        assert (metadata["text_attr_values"][:, 1] == -1).all()
+
+    def test_balanced_sampler_works_with_attribute_metadata(
+        self, temp_dataset
+    ):
+        """Test query-type balancing still works when metadata batches are enabled."""
+        pairs_file = temp_dataset['tmpdir'] / "train_pairs.json"
+        _write_attribute_pairs(pairs_file, count=5, width=7)
+        dataset_configs = [{
+            'image_dir': temp_dataset['image_dir'],
+            'caption_dir': temp_dataset['caption_dir'],
+            'image_list_file': temp_dataset['image_list_file'],
+            'caption_file_suffix': '.txt',
+            'train_pairs_file': str(pairs_file),
+        }]
+
+        def dummy_transform(img):
+            return torch.zeros(3, 32, 32)
+
+        dataloader = get_custom_dataloader(
+            datasets=dataset_configs,
+            batch_size=2,
+            transform=dummy_transform,
+            num_workers=0,
+            mode='train',
+            balance_query_types=True,
+            unique_caption_per_batch=False,
+            include_attribute_metadata=True,
+        )
+
+        sampler = dataloader.batch_sampler.sampler
+        images, _, metadata = next(iter(dataloader))
+
+        assert isinstance(sampler, BalancedByQueryTypeSampler)
+        assert images.shape == (2, 3, 32, 32)
+        assert metadata["image_attr_values"].shape == (2, 7)
+
+
+@pytest.mark.multimodal_unit
+class TestCLIPDataModule:
+    """Test CLIPDataModule custom dataloader wiring."""
+
+    def test_train_forwards_include_attribute_metadata(self, monkeypatch):
+        """Test train dataloader forwards attribute metadata config."""
+        captured = {}
+
+        def fake_get_custom_dataloader(**kwargs):
+            captured.update(kwargs)
+            return "train_loader"
+
+        monkeypatch.setattr(
+            clip_data_module, "get_custom_dataloader", fake_get_custom_dataloader
+        )
+        dataset_config = SimpleNamespace(
+            seed=42,
+            pin_memory=True,
+            train=SimpleNamespace(
+                type="custom",
+                datasets=[{"image_dir": "/tmp/images"}],
+                batch_size=4,
+                num_workers=0,
+                balance_query_types=False,
+                unique_caption_per_batch=False,
+                include_attribute_metadata=True,
+            ),
+            val=SimpleNamespace(datasets=[]),
+        )
+        dm = CLIPDataModule(
+            dataset_config=dataset_config,
+            tokenizer=lambda text: [text],
+            resume_step=0,
+            preprocess=(lambda image: image, lambda image: image),
+            world_size=1,
+        )
+
+        dm._setup_train_dataloader(is_distributed=False)
+
+        assert dm.train_dataset == "train_loader"
+        assert captured["mode"] == "train"
+        assert captured["include_attribute_metadata"] is True
+
+    def test_val_enables_attribute_metadata_for_matching(
+        self, monkeypatch
+    ):
+        """Test metadata-aware validation requests loader metadata."""
+        captured = {}
+
+        def fake_get_custom_dataloader(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(dataset=[0, 1])
+
+        monkeypatch.setattr(
+            clip_data_module,
+            "get_custom_dataloader",
+            fake_get_custom_dataloader,
+        )
+        dataset_config = SimpleNamespace(
+            seed=42,
+            pin_memory=True,
+            train=SimpleNamespace(type="custom"),
+            val=SimpleNamespace(
+                datasets=[{"image_dir": "/tmp/images"}],
+                batch_size=2,
+                num_workers=0,
+                metadata_match_eval=True,
+            ),
+        )
+        data_module = CLIPDataModule(
+            dataset_config=dataset_config,
+            tokenizer=lambda text: [text],
+            resume_step=0,
+            preprocess=(
+                lambda image: image,
+                lambda image: image,
+            ),
+            world_size=1,
+        )
+
+        data_module._setup_val_dataloader()
+
+        assert data_module.val_dataset is not None
+        assert captured["mode"] == "val"
+        assert captured["include_attribute_metadata"] is True
+
+    def test_val_metadata_matching_allows_multiple_datasets(
+        self, monkeypatch
+    ):
+        """Test metadata validation passes all datasets to the strict loader."""
+        captured = {}
+
+        def fake_get_custom_dataloader(**kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(dataset=[0, 1])
+
+        monkeypatch.setattr(
+            clip_data_module,
+            "get_custom_dataloader",
+            fake_get_custom_dataloader,
+        )
+        datasets = [
+            {"image_dir": "/tmp/one"},
+            {"image_dir": "/tmp/two"},
+        ]
+        dataset_config = SimpleNamespace(
+            seed=42,
+            pin_memory=True,
+            train=SimpleNamespace(type="custom"),
+            val=SimpleNamespace(
+                datasets=datasets,
+                batch_size=2,
+                num_workers=0,
+                metadata_match_eval=True,
+            ),
+        )
+        data_module = CLIPDataModule(
+            dataset_config=dataset_config,
+            tokenizer=lambda text: [text],
+            resume_step=0,
+            preprocess=(
+                lambda image: image,
+                lambda image: image,
+            ),
+            world_size=1,
+        )
+
+        data_module._setup_val_dataloader()
+
+        assert captured["datasets"] == datasets
+        assert captured["include_attribute_metadata"] is True

--- a/tests/multimodal_unit_test/clip/test_masked_siglip_loss.py
+++ b/tests/multimodal_unit_test/clip/test_masked_siglip_loss.py
@@ -1,0 +1,752 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for metadata-masked SigLIP loss."""
+
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import torch.multiprocessing as mp
+
+from nvidia_tao_pytorch.multimodal.clip.loss import (
+    masked_siglip_loss as loss_module,
+)
+from nvidia_tao_pytorch.multimodal.clip.loss.masked_siglip_loss import (
+    MetadataMaskedSigLipLoss,
+)
+
+
+def _features():
+    """Build deterministic local image/text features."""
+    image_features = torch.tensor([
+        [0.10, 0.20, 0.30],
+        [0.30, 0.20, 0.10],
+        [0.20, 0.40, 0.10],
+    ])
+    text_features = torch.tensor([
+        [0.20, 0.10, 0.30],
+        [0.10, 0.30, 0.20],
+        [0.40, 0.10, 0.20],
+    ])
+    return image_features, text_features
+
+
+def _manual_siglip_loss(
+    image_features,
+    text_features,
+    logit_scale,
+    logit_bias,
+    valid_terms=None,
+):
+    """Compute SigLIP loss terms directly for expected values."""
+    batch_size = image_features.shape[0]
+    logits = logit_scale * image_features @ text_features.T + logit_bias
+    labels = -torch.ones_like(logits)
+    labels = labels + 2 * torch.eye(batch_size, dtype=logits.dtype)
+    loss_terms = -F.logsigmoid(labels * logits)
+    if valid_terms is not None:
+        loss_terms = loss_terms.masked_select(valid_terms)
+    return loss_terms.sum() / batch_size
+
+
+def _manual_siglip_loss_rectangular(
+    image_features,
+    text_features,
+    logit_scale,
+    logit_bias,
+    positive_text_indices,
+    valid_terms,
+):
+    """Compute SigLIP loss for local images against gathered text rows."""
+    batch_size = image_features.shape[0]
+    logits = logit_scale * image_features @ text_features.T + logit_bias
+    labels = -torch.ones_like(logits)
+    labels[
+        torch.arange(batch_size),
+        positive_text_indices,
+    ] = 1
+    loss_terms = -F.logsigmoid(labels * logits).masked_select(valid_terms)
+    return loss_terms.sum() / batch_size
+
+
+def _mock_distributed_context(monkeypatch, rank=0, world_size=2):
+    """Mock a live default process group without launching worker processes."""
+    monkeypatch.setattr(torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: rank)
+    monkeypatch.setattr(
+        torch.distributed, "get_world_size", lambda: world_size
+    )
+
+
+def _run_two_rank_gloo_gradient_check(rank, world_size, init_method):
+    """Verify gathered text features receive gradients from every rank."""
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        image_features = torch.tensor([
+            [0.40, -0.20],
+            [0.10, 0.50],
+        ])
+        all_text_features = torch.tensor([
+            [0.30, 0.70],
+            [-0.60, 0.20],
+        ])
+        attr_values = torch.tensor([[1], [2]])
+        logit_scale = torch.tensor(1.7)
+        logit_bias = torch.tensor(-0.2)
+
+        local_text_features = (
+            all_text_features[rank:rank + 1].clone().requires_grad_()
+        )
+        loss = MetadataMaskedSigLipLoss(
+            dist_impl="gather",
+            world_size=world_size,
+            rank=rank,
+        )(
+            image_features[rank:rank + 1],
+            local_text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=attr_values[rank:rank + 1],
+            text_attr_values=attr_values[rank:rank + 1],
+        )
+        loss.backward()
+        actual_grad = local_text_features.grad.detach()
+
+        reference_text_features = all_text_features.clone().requires_grad_()
+        per_rank_losses = []
+        for image_rank in range(world_size):
+            logits = (
+                logit_scale
+                * image_features[image_rank:image_rank + 1]
+                @ reference_text_features.T
+                + logit_bias
+            )
+            labels = -torch.ones_like(logits)
+            labels[0, image_rank] = 1
+            per_rank_losses.append(-F.logsigmoid(labels * logits).sum())
+
+        expected_grad = torch.autograd.grad(
+            sum(per_rank_losses),
+            reference_text_features,
+            retain_graph=True,
+        )[0][rank:rank + 1]
+        local_only_grad = torch.autograd.grad(
+            per_rank_losses[rank],
+            reference_text_features,
+        )[0][rank:rank + 1]
+
+        assert torch.allclose(actual_grad, expected_grad)
+        assert not torch.allclose(actual_grad, local_only_grad)
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_two_rank_gloo_uneven_batch_check(rank, world_size, init_method):
+    """Verify uneven local batches fail before feature/metadata gathers."""
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=30),
+    )
+    try:
+        local_batch_size = rank + 1
+        image_features = torch.ones(local_batch_size, 2)
+        text_features = torch.ones(local_batch_size, 2)
+        attr_values = torch.arange(local_batch_size).reshape(-1, 1)
+
+        with pytest.raises(
+            RuntimeError,
+            match="equal local text batch sizes",
+        ):
+            MetadataMaskedSigLipLoss(
+                dist_impl="gather",
+                world_size=world_size,
+                rank=rank,
+            )(
+                image_features,
+                text_features,
+                torch.tensor(1.0),
+                torch.tensor(0.0),
+                image_attr_values=attr_values,
+                text_attr_values=attr_values,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.multimodal_unit
+class TestMetadataMaskedSigLipLoss:
+    """Test metadata-masked SigLIP loss behavior."""
+
+    def test_matches_regular_siglip_without_off_diagonal_metadata_matches(
+        self,
+    ):
+        """Test no mask is applied when only paired metadata matches."""
+        image_features, text_features = _features()
+        logit_scale = torch.tensor(2.0)
+        logit_bias = torch.tensor(-0.5)
+        attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ])
+
+        loss = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+        )
+
+        expected = _manual_siglip_loss(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_legacy_scalar_mode_ignores_optional_accessory_tensors(self):
+        """Test accessory support does not change attribute_match_ignore."""
+        attr_values = torch.tensor([
+            [1, 1],
+            [1, 1],
+            [3, 3],
+        ])
+        loss = MetadataMaskedSigLipLoss(accessory_aware=False)
+
+        legacy_mask = loss.get_valid_term_mask(
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+        )
+        mask_with_unused_accessories = loss.get_valid_term_mask(
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+            image_accessory_ids=torch.tensor([[11], [12], [13]]),
+            text_accessory_ids=torch.tensor([[11], [12], [13]]),
+        )
+
+        assert torch.equal(legacy_mask, mask_with_unused_accessories)
+
+    def test_ignores_off_diagonal_metadata_match(self):
+        """Test metadata-compatible off-diagonal terms are removed."""
+        image_features, text_features = _features()
+        logit_scale = torch.tensor(2.0)
+        logit_bias = torch.tensor(-0.5)
+        image_attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [1, 3],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [1, -1],
+        ])
+
+        loss = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        valid_terms = torch.tensor([
+            [True, True, False],
+            [True, True, True],
+            [True, True, True],
+        ])
+        expected = _manual_siglip_loss(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            valid_terms=valid_terms,
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_keeps_diagonal_positive_even_when_metadata_matches(self):
+        """Test diagonal positives remain valid when metadata matches."""
+        image_features, text_features = _features()
+        attr_values = torch.tensor([
+            [1, 1],
+            [1, 1],
+            [1, 1],
+        ])
+
+        valid_terms = MetadataMaskedSigLipLoss().get_valid_term_mask(
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+        )
+
+        assert torch.equal(
+            valid_terms,
+            torch.eye(3, dtype=torch.bool),
+        )
+
+    def test_unknown_image_metadata_keeps_paired_positive(self):
+        """Test metadata uncertainty never changes the paired label."""
+        image_features, text_features = _features()
+        image_features = image_features[:2]
+        text_features = text_features[:2]
+        logit_scale = torch.tensor(2.0)
+        logit_bias = torch.tensor(-0.5)
+
+        loss = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=torch.tensor([[-1], [2]]),
+            text_attr_values=torch.tensor([[1], [2]]),
+        )
+
+        expected = _manual_siglip_loss(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_accessory_aware_mask_keeps_mismatches_as_negatives(self):
+        """Test only scalar-plus-accessory compatible terms are ignored."""
+        attr_values = torch.tensor([
+            [1, 1],
+            [1, 1],
+            [1, 1],
+        ])
+        image_accessory_ids = torch.tensor([
+            [11, 12],
+            [11, 0],
+            [13, 0],
+        ])
+        text_accessory_ids = torch.tensor([
+            [11, 0],
+            [11, 12],
+            [0, 0],
+        ])
+
+        valid_terms = MetadataMaskedSigLipLoss(
+            accessory_aware=True
+        ).get_valid_term_mask(
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+            image_accessory_ids=image_accessory_ids,
+            text_accessory_ids=text_accessory_ids,
+        )
+
+        assert torch.equal(valid_terms, torch.tensor([
+            [True, False, False],
+            [False, True, False],
+            [True, True, True],
+        ]))
+
+    def test_accessory_aware_mask_requires_accessory_tensors(self):
+        """Test the opt-in mode fails clearly with legacy metadata."""
+        attr_values = torch.tensor([[1, 1], [2, 2]])
+
+        with pytest.raises(ValueError, match="requires image_accessory_ids"):
+            MetadataMaskedSigLipLoss(
+                accessory_aware=True
+            ).get_valid_term_mask(
+                image_attr_values=attr_values,
+                text_attr_values=attr_values,
+            )
+
+    def test_all_wildcard_query_ignores_all_off_diagonal_images(self):
+        """Test all-wildcard query masks every off-diagonal image."""
+        image_features, text_features = _features()
+        logit_scale = torch.tensor(2.0)
+        logit_bias = torch.tensor(-0.5)
+        image_attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 1],
+            [-1, -1],
+            [3, 3],
+        ])
+
+        loss = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        valid_terms = torch.tensor([
+            [True, False, True],
+            [True, True, True],
+            [True, False, True],
+        ])
+        expected = _manual_siglip_loss(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            valid_terms=valid_terms,
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_loss_uses_sum_over_local_batch_size_not_valid_mean(self):
+        """Test normalization is OpenCLIP-compatible sum divided by batch."""
+        image_features, text_features = _features()
+        logit_scale = torch.tensor(2.0)
+        logit_bias = torch.tensor(-0.5)
+        image_attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 1],
+            [-1, -1],
+            [3, 3],
+        ])
+
+        loss = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            logit_scale,
+            logit_bias,
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        valid_terms = torch.tensor([
+            [True, False, True],
+            [True, True, True],
+            [True, False, True],
+        ])
+        logits = logit_scale * image_features @ text_features.T + logit_bias
+        labels = -torch.ones_like(logits) + 2 * torch.eye(3)
+        selected_terms = -F.logsigmoid(labels * logits).masked_select(
+            valid_terms
+        )
+
+        assert torch.allclose(loss, selected_terms.sum() / 3)
+        assert not torch.allclose(loss, selected_terms.mean())
+
+    def test_output_dict_matches_open_clip_shape(self):
+        """Test output_dict returns contrastive_loss key."""
+        image_features, text_features = _features()
+        attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ])
+
+        output = MetadataMaskedSigLipLoss()(
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            image_attr_values=attr_values,
+            text_attr_values=attr_values,
+            output_dict=True,
+        )
+
+        assert set(output) == {"contrastive_loss"}
+        assert output["contrastive_loss"].ndim == 0
+
+    def test_gather_masks_cross_rank_metadata_matches(self, monkeypatch):
+        """Test cross-rank metadata-compatible terms are not negatives."""
+        image_features = torch.tensor([
+            [0.10, 0.20, 0.30],
+            [0.30, 0.20, 0.10],
+        ])
+        text_features = torch.tensor([
+            [0.20, 0.10, 0.30],
+            [0.10, 0.30, 0.20],
+        ])
+        remote_text_features = torch.tensor([
+            [0.40, 0.10, 0.20],
+            [0.30, 0.40, 0.10],
+        ])
+        image_attr_values = torch.tensor([[1], [2]])
+        text_attr_values = torch.tensor([[1], [2]])
+        remote_text_attr_values = torch.tensor([[1], [3]])
+
+        _mock_distributed_context(monkeypatch)
+        monkeypatch.setattr(
+            loss_module.dist_nn,
+            "all_gather",
+            lambda tensor: (tensor, remote_text_features),
+        )
+
+        def fake_all_gather(gathered, tensor):
+            if tensor.ndim == 1:
+                gathered[0].fill_(text_features.shape[0])
+                gathered[1].fill_(remote_text_features.shape[0])
+                return
+            gathered[0].copy_(tensor)
+            gathered[1].copy_(remote_text_attr_values)
+
+        monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+        loss = MetadataMaskedSigLipLoss(
+            dist_impl="gather",
+            world_size=2,
+            rank=0,
+        )(
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        all_text_features = torch.cat(
+            [text_features, remote_text_features], dim=0
+        )
+        valid_terms = torch.tensor([
+            [True, True, False, True],
+            [True, True, True, True],
+        ])
+        expected = _manual_siglip_loss_rectangular(
+            image_features,
+            all_text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            positive_text_indices=torch.tensor([0, 1]),
+            valid_terms=valid_terms,
+        )
+        assert torch.allclose(loss, expected)
+
+    @pytest.mark.skipif(
+        not dist.is_available() or not dist.is_gloo_available(),
+        reason="Two-rank gradient test requires torch.distributed with Gloo.",
+    )
+    def test_gather_propagates_cross_rank_text_gradients(self, tmp_path):
+        """Test real Gloo gather backpropagates remote-rank loss terms."""
+        world_size = 2
+        init_method = f"file://{tmp_path / 'gloo_init'}"
+
+        mp.spawn(
+            _run_two_rank_gloo_gradient_check,
+            args=(world_size, init_method),
+            nprocs=world_size,
+            join=True,
+        )
+
+    @pytest.mark.skipif(
+        not dist.is_available() or not dist.is_gloo_available(),
+        reason="Two-rank batch-size test requires torch.distributed with Gloo.",
+    )
+    def test_gather_rejects_uneven_cross_rank_batches(self, tmp_path):
+        """Test unequal per-rank batches fail before shaped all_gather."""
+        world_size = 2
+        init_method = f"file://{tmp_path / 'gloo_uneven_init'}"
+
+        mp.spawn(
+            _run_two_rank_gloo_uneven_batch_check,
+            args=(world_size, init_method),
+            nprocs=world_size,
+            join=True,
+        )
+
+    def test_gather_masks_cross_rank_accessory_matches(self, monkeypatch):
+        """Test cross-rank scalar+accessory matches are also ignored."""
+        image_features = torch.tensor([
+            [0.10, 0.20, 0.30],
+            [0.30, 0.20, 0.10],
+        ])
+        text_features = torch.tensor([
+            [0.20, 0.10, 0.30],
+            [0.10, 0.30, 0.20],
+        ])
+        remote_text_features = torch.tensor([
+            [0.40, 0.10, 0.20],
+            [0.30, 0.40, 0.10],
+        ])
+        image_attr_values = torch.tensor([[1], [1]])
+        text_attr_values = torch.tensor([[1], [1]])
+        remote_text_attr_values = torch.tensor([[1], [1]])
+        image_accessory_ids = torch.tensor([[11, 12], [13, 0]])
+        text_accessory_ids = torch.tensor([[11, 0], [13, 0]])
+        remote_text_accessory_ids = torch.tensor([[11, 12], [14, 0]])
+
+        _mock_distributed_context(monkeypatch)
+        monkeypatch.setattr(
+            loss_module.dist_nn,
+            "all_gather",
+            lambda tensor: (tensor, remote_text_features),
+        )
+
+        def fake_all_gather(gathered, tensor):
+            if tensor.ndim == 1:
+                gathered[0].fill_(text_features.shape[0])
+                gathered[1].fill_(remote_text_features.shape[0])
+            elif tensor.shape[1] == 1:
+                gathered[0].copy_(tensor)
+                gathered[1].copy_(remote_text_attr_values)
+            else:
+                gathered[0].copy_(tensor)
+                gathered[1].copy_(remote_text_accessory_ids)
+
+        monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+        loss = MetadataMaskedSigLipLoss(
+            dist_impl="gather",
+            world_size=2,
+            rank=0,
+            accessory_aware=True,
+        )(
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+            image_accessory_ids=image_accessory_ids,
+            text_accessory_ids=text_accessory_ids,
+        )
+
+        all_text_features = torch.cat(
+            [text_features, remote_text_features], dim=0
+        )
+        valid_terms = torch.tensor([
+            [True, True, False, True],
+            [True, True, True, True],
+        ])
+        expected = _manual_siglip_loss_rectangular(
+            image_features,
+            all_text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            positive_text_indices=torch.tensor([0, 1]),
+            valid_terms=valid_terms,
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_gather_places_rank_one_positives_in_its_text_chunk(
+        self, monkeypatch
+    ):
+        """Test nonzero ranks use their gathered text chunk for positives."""
+        image_features = torch.tensor([
+            [0.10, 0.20, 0.30],
+            [0.30, 0.20, 0.10],
+        ])
+        text_features = torch.tensor([
+            [0.20, 0.10, 0.30],
+            [0.10, 0.30, 0.20],
+        ])
+        remote_text_features = torch.tensor([
+            [0.40, 0.10, 0.20],
+            [0.30, 0.40, 0.10],
+        ])
+        image_attr_values = torch.tensor([[1], [2]])
+        text_attr_values = torch.tensor([[1], [2]])
+        remote_text_attr_values = torch.tensor([[3], [4]])
+
+        _mock_distributed_context(monkeypatch, rank=1)
+        monkeypatch.setattr(
+            loss_module.dist_nn,
+            "all_gather",
+            lambda tensor: (remote_text_features, tensor),
+        )
+
+        def fake_all_gather(gathered, tensor):
+            if tensor.ndim == 1:
+                gathered[0].fill_(remote_text_features.shape[0])
+                gathered[1].fill_(text_features.shape[0])
+            else:
+                gathered[0].copy_(remote_text_attr_values)
+                gathered[1].copy_(tensor)
+
+        monkeypatch.setattr(torch.distributed, "all_gather", fake_all_gather)
+
+        loss = MetadataMaskedSigLipLoss(
+            dist_impl="gather",
+            world_size=2,
+            rank=1,
+        )(
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        expected = _manual_siglip_loss_rectangular(
+            image_features,
+            torch.cat([remote_text_features, text_features], dim=0),
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            positive_text_indices=torch.tensor([2, 3]),
+            valid_terms=torch.ones((2, 4), dtype=torch.bool),
+        )
+        assert torch.allclose(loss, expected)
+
+    def test_gather_rejects_mismatched_process_group(self, monkeypatch):
+        """Test stale trainer coordinates fail before entering a collective."""
+        image_features, text_features = _features()
+        attr_values = torch.tensor([[1], [2], [3]])
+        _mock_distributed_context(monkeypatch, rank=0, world_size=4)
+
+        with pytest.raises(RuntimeError, match="distributed context mismatch"):
+            MetadataMaskedSigLipLoss(
+                dist_impl="gather",
+                world_size=2,
+                rank=0,
+            )(
+                image_features,
+                text_features,
+                torch.tensor(2.0),
+                torch.tensor(-0.5),
+                image_attr_values=attr_values,
+                text_attr_values=attr_values,
+            )
+
+    def test_rejects_unsupported_dist_impl(self):
+        """Test unsupported distributed modes fail clearly."""
+        image_features, text_features = _features()
+        attr_values = torch.tensor([
+            [1, 1],
+            [2, 2],
+            [3, 3],
+        ])
+
+        with pytest.raises(ValueError, match="local.*gather"):
+            MetadataMaskedSigLipLoss(dist_impl="bidir", world_size=2)(
+                image_features,
+                text_features,
+                torch.tensor(2.0),
+                torch.tensor(-0.5),
+                image_attr_values=attr_values,
+                text_attr_values=attr_values,
+            )

--- a/tests/multimodal_unit_test/clip/test_metadata_mask.py
+++ b/tests/multimodal_unit_test/clip/test_metadata_mask.py
@@ -1,0 +1,174 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for CLIP metadata match masks."""
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.multimodal.clip.loss.metadata_mask import (
+    build_accessory_match_mask,
+    build_attribute_match_mask,
+)
+
+
+@pytest.mark.multimodal_unit
+class TestBuildAttributeMatchMask:
+    """Test text-query to image-attribute matching."""
+
+    def test_wildcards_match_only_specified_attributes(self):
+        """Test negative text values are treated as wildcards."""
+        image_attr_values = torch.tensor([
+            [1, 6, 2, 5, 8, 5, 2],
+            [2, 3, 2, 5, 12, 7, 3],
+            [1, 6, 1, 3, 8, 5, 1],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 6, 2, 5, -1, -1, -1],
+            [2, 3, -1, 5, -1, -1, -1],
+            [1, 6, -1, -1, 8, -1, -1],
+        ])
+
+        mask = build_attribute_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        expected = torch.tensor([
+            [True, False, False],
+            [False, True, False],
+            [True, False, True],
+        ])
+        assert mask.dtype == torch.bool
+        assert torch.equal(mask, expected)
+
+    def test_no_wildcards_requires_exact_match(self):
+        """Test fully specified queries require exact row equality."""
+        image_attr_values = torch.tensor([
+            [1, 2, 3],
+            [1, 2, 4],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 2, 3],
+            [1, 2, 5],
+        ])
+
+        mask = build_attribute_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        assert torch.equal(mask, torch.tensor([
+            [True, False],
+            [False, False],
+        ]))
+
+    def test_all_wildcard_query_matches_all_images(self):
+        """Test a query with no specified attributes matches every image."""
+        image_attr_values = torch.tensor([
+            [1, 2, 3],
+            [4, 5, 6],
+        ])
+        text_attr_values = torch.tensor([[-1, -1, -1]])
+
+        mask = build_attribute_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        assert torch.equal(mask, torch.tensor([[True, True]]))
+
+    def test_unknown_image_does_not_satisfy_specified_query(self):
+        """Test missing image metadata is not a symmetric wildcard."""
+        image_attr_values = torch.tensor([
+            [-1, 2],
+            [1, 2],
+        ])
+        text_attr_values = torch.tensor([
+            [1, 2],
+            [-1, 2],
+        ])
+
+        mask = build_attribute_match_mask(
+            image_attr_values=image_attr_values,
+            text_attr_values=text_attr_values,
+        )
+
+        assert torch.equal(mask, torch.tensor([
+            [False, True],
+            [True, True],
+        ]))
+
+    def test_requires_rank_two_tensors(self):
+        """Test input tensors must be rank two."""
+        with pytest.raises(ValueError, match="image_attr_values"):
+            build_attribute_match_mask(
+                image_attr_values=torch.tensor([1, 2, 3]),
+                text_attr_values=torch.tensor([[1, 2, 3]]),
+            )
+        with pytest.raises(ValueError, match="text_attr_values"):
+            build_attribute_match_mask(
+                image_attr_values=torch.tensor([[1, 2, 3]]),
+                text_attr_values=torch.tensor([1, 2, 3]),
+            )
+
+    def test_requires_matching_attribute_width(self):
+        """Test image/text attribute widths must match."""
+        with pytest.raises(ValueError, match="same attribute width"):
+            build_attribute_match_mask(
+                image_attr_values=torch.tensor([[1, 2, 3]]),
+                text_attr_values=torch.tensor([[1, 2]]),
+            )
+
+
+@pytest.mark.multimodal_unit
+class TestBuildAccessoryMatchMask:
+    """Test required-accessory subset matching."""
+
+    def test_requires_every_positive_query_accessory(self):
+        """Test padding is ignored and all required IDs must be present."""
+        image_accessory_ids = torch.tensor([
+            [11, 12, 0],
+            [11, 0, 0],
+            [12, 13, 0],
+        ])
+        text_accessory_ids = torch.tensor([
+            [11, 0],
+            [11, 12],
+            [0, 0],
+        ])
+
+        mask = build_accessory_match_mask(
+            image_accessory_ids=image_accessory_ids,
+            text_accessory_ids=text_accessory_ids,
+        )
+
+        assert torch.equal(mask, torch.tensor([
+            [True, True, False],
+            [True, False, False],
+            [True, True, True],
+        ]))
+
+    def test_rejects_invalid_shapes_and_negative_ids(self):
+        """Test accessory tensors must be padded rank-two non-negative IDs."""
+        with pytest.raises(ValueError, match="image_accessory_ids"):
+            build_accessory_match_mask(
+                torch.tensor([1, 2]),
+                torch.tensor([[1, 2]]),
+            )
+        with pytest.raises(ValueError, match="non-negative"):
+            build_accessory_match_mask(
+                torch.tensor([[1, -1]]),
+                torch.tensor([[1, 0]]),
+            )

--- a/tests/multimodal_unit_test/clip/test_pas_eval.py
+++ b/tests/multimodal_unit_test/clip/test_pas_eval.py
@@ -1,0 +1,710 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for direct PAS evaluation helpers."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+import nvidia_tao_pytorch.multimodal.clip.model.evaluation.pas as pas
+from nvidia_tao_pytorch.config.clip.default_config import (
+    CLIPEvaluateConfig,
+    CLIPInferenceEvalConfig,
+)
+from nvidia_tao_pytorch.multimodal.clip.model.evaluation.pas import (
+    PasPair,
+    _extract_image_embeddings,
+    _pair_image_key,
+    _resolve_existing_image_items,
+    _unique_image_candidates,
+    aggregate_metric_rows,
+    evaluate_text_to_image,
+    evaluate_text_to_image_by_metadata,
+    load_pas_pairs,
+)
+from nvidia_tao_pytorch.multimodal.clip.model.tokenizers import (
+    CLIPCompatibleTokenizer,
+    SigLIP2WrappedTokenizer,
+)
+
+
+def _write_attribute_vocab(path, width=2, not_visible=False):
+    """Write a minimal ordered scalar vocabulary."""
+    attributes = [f"attribute_{index}" for index in range(width)]
+    value_to_id = {attribute: {} for attribute in attributes}
+    if not_visible:
+        attributes = ["top outer color", "top outer type"]
+        value_to_id = {
+            "top outer color": {
+                "__missing__": 0,
+                "black": 2,
+                "not visible": 8,
+            },
+            "top outer type": {
+                "__missing__": 0,
+                "not visible": 5,
+                "t shirt": 9,
+            },
+        }
+    path.write_text(
+        json.dumps(
+            {
+                "attributes": attributes,
+                "value_to_id": value_to_id,
+            }
+        )
+    )
+
+
+def _write_accessory_vocab(path):
+    """Write a minimal split-complete accessory vocabulary."""
+    path.write_text(
+        json.dumps(
+            {
+                "unknown_id": 0,
+                "source_splits": ["train", "val", "test"],
+                "id_to_value": ["__unknown__", "bag", "hat"],
+                "value_to_id": {
+                    "__unknown__": 0,
+                    "bag": 1,
+                    "hat": 2,
+                },
+                "vocab_sha256": "test-vocab",
+            }
+        )
+    )
+
+
+def _metric_row(
+    dataset,
+    query_type,
+    num_queries,
+    map_score,
+    first_pos=1.0,
+):
+    return {
+        "Dataset": dataset,
+        "QueryType": query_type,
+        "EasyAttribute": "",
+        "num_queries": num_queries,
+        "gallery_size": 10,
+        "avg_gt_per_query": 1.0,
+        "mAP": map_score,
+        "Rank-1": map_score,
+        "Rank-5": map_score,
+        "Separability": map_score,
+        "Match@5": map_score,
+        "Zero@5": 1.0 - map_score,
+        "First Pos": first_pos,
+    }
+
+
+@pytest.mark.multimodal_unit
+def test_pas_ground_truth_mode_defaults_to_paired_caption():
+    assert CLIPEvaluateConfig().pas_ground_truth_mode == "paired_caption"
+
+
+@pytest.mark.multimodal_unit
+def test_inference_config_excludes_pas_ground_truth_mode():
+    assert not hasattr(
+        CLIPInferenceEvalConfig(),
+        "pas_ground_truth_mode",
+    )
+
+
+@pytest.mark.multimodal_unit
+def test_query_metrics_assign_unique_ranks_to_tied_positives():
+    metrics = pas._compute_query_metrics(
+        np.array([0.8, 0.8, 0.2]),
+        gt_indices=[0, 1],
+    )
+
+    assert metrics["ap"] == pytest.approx(1.0)
+    assert metrics["auc"] == pytest.approx(1.0)
+    assert metrics["first_pos"] == 1.0
+
+
+@pytest.mark.multimodal_unit
+def test_query_metrics_break_positive_negative_tie_by_gallery_order():
+    metrics = pas._compute_query_metrics(
+        np.array([0.8, 0.8, 0.2]),
+        gt_indices=[1],
+    )
+
+    assert metrics["first_pos"] == 2.0
+    assert metrics["rank1"] == 0.0
+    assert metrics["ap"] == pytest.approx(0.5)
+    assert metrics["auc"] == pytest.approx(0.5)
+
+
+@pytest.mark.multimodal_unit
+def test_metric_aggregate_macro_averages_datasets():
+    rows = [
+        _metric_row("A", "easy", 10, 0.0),
+        _metric_row("B", "easy", 1, 1.0),
+    ]
+
+    aggregate = aggregate_metric_rows(rows, k=5, dataset_names=("A", "B"))
+
+    assert aggregate[0]["Dataset"] == "AVG_2_DATASETS"
+    assert aggregate[0]["num_queries"] == pytest.approx(5.5)
+    assert aggregate[0]["mAP"] == pytest.approx(0.5)
+
+
+@pytest.mark.multimodal_unit
+def test_metric_weighted_aggregate_uses_query_count():
+    rows = [
+        _metric_row("A", "easy", 10, 0.0, first_pos=100.0),
+        _metric_row("B", "easy", 1, 1.0, first_pos=1.0),
+    ]
+
+    aggregate = aggregate_metric_rows(
+        rows,
+        k=5,
+        dataset_names=("A", "B"),
+        weighted=True,
+    )
+
+    assert aggregate[0]["Dataset"] == "WAVG_2_DATASETS"
+    assert aggregate[0]["num_queries"] == pytest.approx(11)
+    assert aggregate[0]["mAP"] == pytest.approx(1 / 11)
+    assert np.isnan(aggregate[0]["First Pos"])
+
+
+@pytest.mark.multimodal_unit
+def test_metadata_eval_filters_matches_by_required_accessories():
+    pairs = [
+        PasPair(
+            dataset="D",
+            query_type="hard",
+            caption="person with bag",
+            unique_name="img0.jpg",
+            image_path="images/D/img0.jpg",
+            prepared_image_path=Path("img0.jpg"),
+            image_attr_values=(1, 2),
+            text_attr_values=(1, 2),
+            image_accessory_ids=(1,),
+            text_accessory_ids=(1,),
+        ),
+        PasPair(
+            dataset="D",
+            query_type="hard",
+            caption="person with hat",
+            unique_name="img1.jpg",
+            image_path="images/D/img1.jpg",
+            prepared_image_path=Path("img1.jpg"),
+            image_attr_values=(1, 2),
+            text_attr_values=(1, 2),
+            image_accessory_ids=(2,),
+            text_accessory_ids=(2,),
+        ),
+        PasPair(
+            dataset="D",
+            query_type="hard",
+            caption="person with bag and hat",
+            unique_name="img2.jpg",
+            image_path="images/D/img2.jpg",
+            prepared_image_path=Path("img2.jpg"),
+            image_attr_values=(1, 2),
+            text_attr_values=(1, 2),
+            image_accessory_ids=(1, 2),
+            text_accessory_ids=(1, 2),
+        ),
+    ]
+    image_embeddings = {
+        f"D\timages/D/img{index}.jpg": np.eye(3, dtype=np.float32)[index]
+        for index in range(3)
+    }
+    text_embeddings = {
+        pair.caption: np.eye(3, dtype=np.float32)[index]
+        for index, pair in enumerate(pairs)
+    }
+
+    scalar_rows = evaluate_text_to_image_by_metadata(
+        pairs,
+        image_embeddings,
+        text_embeddings,
+        ground_truth_mode="scalar_attributes",
+    )
+    accessory_rows = evaluate_text_to_image_by_metadata(
+        pairs,
+        image_embeddings,
+        text_embeddings,
+        ground_truth_mode="scalar_plus_accessories",
+    )
+
+    assert scalar_rows[0]["avg_gt_per_query"] == pytest.approx(3.0)
+    assert accessory_rows[0]["avg_gt_per_query"] == pytest.approx(5 / 3)
+
+
+@pytest.mark.multimodal_unit
+def test_metadata_eval_deduplicates_caption_and_unions_signatures():
+    pairs = [
+        PasPair(
+            dataset="D",
+            query_type="hard",
+            caption="person carrying an item",
+            unique_name="img0.jpg",
+            image_path="images/D/img0.jpg",
+            prepared_image_path=Path("img0.jpg"),
+            image_attr_values=(1,),
+            text_attr_values=(1,),
+            image_accessory_ids=(1,),
+            text_accessory_ids=(1,),
+        ),
+        PasPair(
+            dataset="D",
+            query_type="hard",
+            caption="person carrying an item",
+            unique_name="img1.jpg",
+            image_path="images/D/img1.jpg",
+            prepared_image_path=Path("img1.jpg"),
+            image_attr_values=(2,),
+            text_attr_values=(2,),
+            image_accessory_ids=(2,),
+            text_accessory_ids=(2,),
+        ),
+        PasPair(
+            dataset="D",
+            query_type="original_captions",
+            caption="gallery-only caption",
+            unique_name="img2.jpg",
+            image_path="images/D/img2.jpg",
+            prepared_image_path=Path("img2.jpg"),
+            image_attr_values=(1,),
+            text_attr_values=(1,),
+            image_accessory_ids=(1,),
+            text_accessory_ids=(),
+        ),
+    ]
+    image_embeddings = {
+        f"D\timages/D/img{index}.jpg": np.eye(3, dtype=np.float32)[index]
+        for index in range(3)
+    }
+
+    rows = evaluate_text_to_image_by_metadata(
+        pairs,
+        image_embeddings,
+        {
+            "person carrying an item": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        },
+        ground_truth_mode="scalar_plus_accessories",
+    )
+
+    assert rows[0]["num_queries"] == 1
+    assert rows[0]["avg_gt_per_query"] == pytest.approx(3.0)
+
+
+@pytest.mark.multimodal_unit
+def test_easy_query_ground_truth_modes_remain_separate():
+    pairs = [
+        PasPair(
+            dataset="D",
+            query_type="easy",
+            caption=f"easy query {index}",
+            unique_name=f"img{index}.jpg",
+            image_path=f"images/D/img{index}.jpg",
+            prepared_image_path=Path(f"img{index}.jpg"),
+            image_attr_values=(1, 2),
+            text_attr_values=(1, -1),
+            image_accessory_ids=(index + 1,),
+            text_accessory_ids=(),
+        )
+        for index in range(2)
+    ]
+    image_embeddings = {
+        f"D\timages/D/img{index}.jpg": np.eye(2, dtype=np.float32)[index]
+        for index in range(2)
+    }
+    text_embeddings = {
+        f"easy query {index}": np.eye(2, dtype=np.float32)[index] for index in range(2)
+    }
+
+    paired = evaluate_text_to_image(pairs, image_embeddings, text_embeddings)
+    scalar = evaluate_text_to_image_by_metadata(
+        pairs,
+        image_embeddings,
+        text_embeddings,
+        ground_truth_mode="scalar_attributes",
+    )
+    accessory = evaluate_text_to_image_by_metadata(
+        pairs,
+        image_embeddings,
+        text_embeddings,
+        ground_truth_mode="scalar_plus_accessories",
+    )
+
+    assert paired[0]["avg_gt_per_query"] == pytest.approx(1.0)
+    assert scalar[0]["avg_gt_per_query"] == pytest.approx(2.0)
+    assert accessory == scalar
+
+
+@pytest.mark.multimodal_unit
+def test_resolve_existing_image_items_uses_later_duplicate(tmp_path):
+    missing_path = tmp_path / "missing.jpg"
+    existing_path = tmp_path / "existing.jpg"
+    existing_path.write_bytes(b"image")
+    pairs = [
+        PasPair(
+            dataset="D",
+            query_type="easy",
+            caption="one",
+            unique_name="missing.jpg",
+            image_path="images/D/img0.jpg",
+            prepared_image_path=missing_path,
+        ),
+        PasPair(
+            dataset="D",
+            query_type="easy",
+            caption="two",
+            unique_name="existing.jpg",
+            image_path="images/D/img0.jpg",
+            prepared_image_path=existing_path,
+        ),
+    ]
+    key = _pair_image_key(pairs[0])
+
+    candidates = _unique_image_candidates(pairs)
+    resolved = _resolve_existing_image_items(candidates, pairs)
+
+    assert candidates == [(key, missing_path)]
+    assert resolved == [(key, existing_path)]
+
+
+@pytest.mark.multimodal_unit
+def test_image_embeddings_require_prepared_images(tmp_path):
+    pair = PasPair(
+        dataset="D",
+        query_type="easy",
+        caption="missing",
+        unique_name="missing.jpg",
+        image_path="images/D/img0.jpg",
+        prepared_image_path=tmp_path / "missing.jpg",
+    )
+
+    with pytest.raises(ValueError, match="PAS prepared images are missing"):
+        _extract_image_embeddings(
+            model=object(),
+            pairs=[pair],
+            batch_size=1,
+            num_workers=0,
+            device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.multimodal_unit
+@pytest.mark.parametrize(
+    ("canonicalize_text", "expected_tokenizer_text"),
+    [
+        (False, "A RED_Shirt!"),
+        (True, "a red shirt"),
+    ],
+)
+def test_text_embeddings_leave_canonicalization_to_tokenizer(
+    canonicalize_text,
+    expected_tokenizer_text,
+):
+    class RecordingProcessor:
+        def __init__(self):
+            self.text_batches = []
+
+        def __call__(self, *, text, **kwargs):
+            self.text_batches.append(list(text))
+            batch_size = len(text)
+            return {
+                "input_ids": torch.ones((batch_size, 2), dtype=torch.long),
+                "attention_mask": torch.ones(
+                    (batch_size, 2),
+                    dtype=torch.long,
+                ),
+            }
+
+    class TextEncoder:
+        def get_text_features(self, input_ids, attention_mask=None):
+            return input_ids.float()
+
+    processor = RecordingProcessor()
+    tokenizer = CLIPCompatibleTokenizer(
+        SigLIP2WrappedTokenizer(
+            processor,
+            canonicalize=canonicalize_text,
+        )
+    )
+    model = SimpleNamespace(
+        tokenizer=tokenizer,
+        model=SimpleNamespace(
+            backbone=SimpleNamespace(inner=TextEncoder()),
+        ),
+        eval=lambda: None,
+    )
+
+    embeddings = pas._extract_text_embeddings(
+        model,
+        ["A RED_Shirt!"],
+        batch_size=1,
+        device=torch.device("cpu"),
+    )
+
+    assert processor.text_batches == [[expected_tokenizer_text]]
+    assert list(embeddings) == ["A RED_Shirt!"]
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_treats_not_visible_as_missing(tmp_path):
+    pairs_file = tmp_path / "val_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "easy",
+                    "caption": "not visible query",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                    "image_attr_values": [8, 5],
+                    "text_attr_values": [8, 5],
+                }
+            ]
+        )
+    )
+    _write_attribute_vocab(
+        tmp_path / "attribute_vocab.json",
+        not_visible=True,
+    )
+
+    pairs = load_pas_pairs(
+        {"image_dir": str(tmp_path / "images")},
+        pairs_file,
+        ground_truth_mode="scalar_attributes",
+    )
+
+    assert pairs[0].image_attr_values == (-1, -1)
+    assert pairs[0].text_attr_values == (-1, -1)
+
+
+@pytest.mark.multimodal_unit
+@pytest.mark.parametrize("query_type", pas.PAS_QUERY_TYPES)
+def test_load_pas_pairs_accepts_supported_query_types(tmp_path, query_type):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": query_type,
+                    "caption": "supported query",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                }
+            ]
+        )
+    )
+
+    pairs = load_pas_pairs(
+        {"image_dir": str(tmp_path / "images")},
+        pairs_file,
+    )
+
+    assert pairs[0].query_type == query_type
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_rejects_unknown_query_type(tmp_path):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "medum",
+                    "caption": "query with typo",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                }
+            ]
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="query_type must be one of",
+    ):
+        load_pas_pairs(
+            {"image_dir": str(tmp_path / "images")},
+            pairs_file,
+        )
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_reads_valid_accessories(tmp_path):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "hard",
+                    "caption": "person with bag",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                    "image_attr_values": [1, 2],
+                    "text_attr_values": [1, 2],
+                    "image_accessory_ids": [1, 2],
+                    "text_accessory_ids": [1],
+                }
+            ]
+        )
+    )
+    _write_attribute_vocab(tmp_path / "attribute_vocab.json")
+    _write_accessory_vocab(tmp_path / "accessory_vocab.json")
+
+    pairs = load_pas_pairs(
+        {"image_dir": str(tmp_path / "images")},
+        pairs_file,
+        ground_truth_mode="scalar_plus_accessories",
+    )
+
+    assert pairs[0].image_accessory_ids == (1, 2)
+    assert pairs[0].text_accessory_ids == (1,)
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_requires_accessory_fields(tmp_path):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "hard",
+                    "caption": "legacy query",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                    "image_attr_values": [1, 2],
+                    "text_attr_values": [1, 2],
+                }
+            ]
+        )
+    )
+    _write_attribute_vocab(tmp_path / "attribute_vocab.json")
+    _write_accessory_vocab(tmp_path / "accessory_vocab.json")
+
+    with pytest.raises(ValueError, match="fields are missing"):
+        load_pas_pairs(
+            {"image_dir": str(tmp_path / "images")},
+            pairs_file,
+            ground_truth_mode="scalar_plus_accessories",
+        )
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_rejects_inconsistent_accessories(tmp_path):
+    pairs_file = tmp_path / "test_pairs.json"
+    base = {
+        "dataset": "D",
+        "query_type": "hard",
+        "image_path": "images/D/img0.jpg",
+        "image_attr_values": [1, 2],
+        "text_attr_values": [1, 2],
+    }
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    **base,
+                    "caption": "person with bag",
+                    "unique_name": "img0_a.jpg",
+                    "image_accessory_ids": [1],
+                    "text_accessory_ids": [1],
+                },
+                {
+                    **base,
+                    "caption": "person with hat",
+                    "unique_name": "img0_b.jpg",
+                    "image_accessory_ids": [2],
+                    "text_accessory_ids": [2],
+                },
+            ]
+        )
+    )
+    _write_attribute_vocab(tmp_path / "attribute_vocab.json")
+    _write_accessory_vocab(tmp_path / "accessory_vocab.json")
+
+    with pytest.raises(ValueError, match="inconsistent accessory"):
+        load_pas_pairs(
+            {"image_dir": str(tmp_path / "images")},
+            pairs_file,
+            ground_truth_mode="scalar_plus_accessories",
+        )
+
+
+@pytest.mark.multimodal_unit
+@pytest.mark.parametrize("invalid_id", [1.9, "2", True])
+def test_load_pas_pairs_rejects_non_integer_scalar_ids(tmp_path, invalid_id):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "easy",
+                    "caption": "query",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                    "image_attr_values": [invalid_id, 2],
+                    "text_attr_values": [1, 2],
+                }
+            ]
+        )
+    )
+    _write_attribute_vocab(tmp_path / "attribute_vocab.json")
+
+    with pytest.raises(ValueError, match="actual integer IDs"):
+        load_pas_pairs(
+            {"image_dir": str(tmp_path / "images")},
+            pairs_file,
+            ground_truth_mode="scalar_attributes",
+        )
+
+
+@pytest.mark.multimodal_unit
+def test_load_pas_pairs_requires_scalar_fields(tmp_path):
+    pairs_file = tmp_path / "test_pairs.json"
+    pairs_file.write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": "D",
+                    "query_type": "easy",
+                    "caption": "query",
+                    "unique_name": "img0.jpg",
+                    "image_path": "images/D/img0.jpg",
+                    "image_attr_values": [1, 2],
+                }
+            ]
+        )
+    )
+    _write_attribute_vocab(tmp_path / "attribute_vocab.json")
+
+    with pytest.raises(ValueError, match="text_attr_values"):
+        load_pas_pairs(
+            {"image_dir": str(tmp_path / "images")},
+            pairs_file,
+            ground_truth_mode="scalar_attributes",
+        )

--- a/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
+++ b/tests/multimodal_unit_test/clip/test_pl_clip_model_validation.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for exact PAS validation during CLIP training."""
+
+from pathlib import Path
+from types import MethodType, SimpleNamespace
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model as pl_clip_model
+from nvidia_tao_pytorch.config.clip.default_config import CLIPValDataConfig
+from nvidia_tao_pytorch.multimodal.clip.model.evaluation.pas import (
+    PAS_METADATA_QUERY_TYPES,
+    PasPair,
+    build_pas_embedding_maps_from_rows,
+    evaluate_pas_metadata_embeddings,
+)
+from nvidia_tao_pytorch.multimodal.clip.model.evaluation.retrieval import (
+    RetrievalMetrics,
+)
+from nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model import (
+    CLIPPlModel,
+    _all_gather_variable_rows,
+    _broadcast_pas_metrics,
+)
+
+
+class _FeatureModel:
+    """Minimal image/text encoder used by validation-step tests."""
+
+    def __call__(self, image=None, text=None):
+        if image is not None:
+            return {"image_features": image}
+        return {"text_features": text}
+
+
+class _CaptureEvaluator:
+    """Capture standard paired-retrieval evaluator inputs."""
+
+    def __init__(self):
+        self.calls = []
+
+    def evaluate_bidirectional(self, image_embeddings, text_embeddings, **kwargs):
+        self.calls.append(
+            {
+                "image_embeddings": image_embeddings,
+                "text_embeddings": text_embeddings,
+                "kwargs": kwargs,
+            }
+        )
+        metrics = RetrievalMetrics(
+            recall_at_k={1: 1.0, 5: 1.0},
+            map_score=1.0,
+            median_rank=1.0,
+            mean_rank=1.0,
+            auc=1.0,
+        )
+        return {
+            "image_to_text": metrics,
+            "text_to_image": metrics,
+        }
+
+
+def _pas_pairs():
+    """Build two one-image galleries with easy/medium/hard queries."""
+    pairs = []
+    for dataset_index, dataset in enumerate(("dataset_a", "dataset_b"), start=1):
+        for row_offset, query_type in enumerate(PAS_METADATA_QUERY_TYPES):
+            pairs.append(
+                PasPair(
+                    dataset=dataset,
+                    query_type=query_type,
+                    caption=f"{dataset} {query_type}",
+                    unique_name=f"{dataset}_{row_offset}.jpg",
+                    image_path=f"images/{dataset}/person.jpg",
+                    prepared_image_path=Path(
+                        f"/unused/{dataset}_{row_offset}.jpg"
+                    ),
+                    image_attr_values=(dataset_index,),
+                    text_attr_values=(dataset_index,),
+                    image_accessory_ids=(1,),
+                    text_accessory_ids=(1,) if query_type == "hard" else (),
+                )
+            )
+    return pairs
+
+
+def _pas_row_features():
+    """Return normalized row features aligned with ``_pas_pairs``."""
+    image_rows = []
+    text_rows = []
+    for dataset_index in (0, 1):
+        feature = torch.tensor(
+            [1.0, 0.0] if dataset_index == 0 else [0.0, 1.0]
+        )
+        for _ in PAS_METADATA_QUERY_TYPES:
+            image_rows.append(feature)
+            text_rows.append(feature)
+    return torch.stack(image_rows), torch.stack(text_rows)
+
+
+def _validation_model(metadata_match_eval, evaluator):
+    """Build a lightweight object for calling validation methods."""
+    logged = []
+    model = SimpleNamespace(
+        metadata_match_eval=metadata_match_eval,
+        metadata_match_mode="scalar_plus_accessories",
+        retrieval_evaluator=evaluator,
+        image_embeddings=[],
+        text_embeddings=[],
+        pas_row_indices=[],
+        pas_validation_datasets=[],
+        _pas_validation_pairs=_pas_pairs() if metadata_match_eval else None,
+        model=_FeatureModel(),
+        tokenizer=None,
+        device=torch.device("cpu"),
+        status_logging_dict={},
+        log=lambda *args, **kwargs: logged.append((args, kwargs)),
+        logged=logged,
+        trainer=SimpleNamespace(sanity_checking=True),
+    )
+    for method_name in (
+        "_evaluate_accumulated_retrieval",
+        "_evaluate_accumulated_pas",
+        "_load_pas_validation_pairs",
+        "_log_pas_metrics",
+        "_evaluate_and_log_paired_retrieval",
+    ):
+        setattr(
+            model,
+            method_name,
+            MethodType(getattr(CLIPPlModel, method_name), model),
+        )
+    return model
+
+
+def _run_two_rank_pas_validation(rank, world_size, init_method):
+    """Exercise uneven row gathering and PAS metric broadcast with Gloo."""
+    dist.init_process_group(
+        "gloo",
+        rank=rank,
+        world_size=world_size,
+        init_method=init_method,
+    )
+    try:
+        pairs = _pas_pairs()
+        image_rows, text_rows = _pas_row_features()
+        indices = (
+            torch.tensor([0, 2, 4, 5])
+            if rank == 0
+            else torch.tensor([1, 3])
+        )
+        gathered_images = _all_gather_variable_rows(
+            image_rows[indices],
+            torch.device("cpu"),
+        )
+        gathered_text = _all_gather_variable_rows(
+            text_rows[indices],
+            torch.device("cpu"),
+        )
+        gathered_indices = _all_gather_variable_rows(
+            indices[:, None],
+            torch.device("cpu"),
+        )
+
+        weighted_rows = None
+        if rank == 0:
+            image_embeddings, text_embeddings = (
+                build_pas_embedding_maps_from_rows(
+                    pairs,
+                    gathered_indices.flatten(),
+                    gathered_images,
+                    gathered_text,
+                )
+            )
+            output = evaluate_pas_metadata_embeddings(
+                pairs,
+                image_embeddings,
+                text_embeddings,
+                ground_truth_mode="scalar_plus_accessories",
+            )
+            weighted_rows = output["metadata_weighted_aggregate"]
+        metrics = _broadcast_pas_metrics(
+            weighted_rows,
+            torch.device("cpu"),
+        )
+        assert set(metrics) == set(PAS_METADATA_QUERY_TYPES)
+        assert all(value["mAP"] == 1.0 for value in metrics.values())
+        assert all(value["num_queries"] == 2 for value in metrics.values())
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.multimodal_unit
+class TestCLIPPASValidation:
+    """Test opt-in exact PAS validation."""
+
+    def test_metadata_match_eval_defaults_to_paired_validation(self):
+        """Existing specs retain paired diagonal validation."""
+        config = CLIPValDataConfig()
+
+        assert config.metadata_match_eval is False
+        assert config.metadata_match_mode == "scalar_attributes"
+
+    def test_validation_step_collects_pas_row_indices(self):
+        """Metadata validation collects embeddings and stable split rows."""
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        image_features = torch.eye(2)
+        text_features = torch.eye(2)
+        metadata = {
+            "image_attr_values": torch.tensor([[1], [2]]),
+            "text_attr_values": torch.tensor([[1], [2]]),
+            "image_accessory_ids": torch.tensor([[1], [1]]),
+            "text_accessory_ids": torch.tensor([[0], [1]]),
+            "pas_row_index": torch.tensor([3, 4]),
+        }
+
+        CLIPPlModel.validation_step(
+            model,
+            (image_features, text_features, metadata),
+            batch_idx=0,
+        )
+
+        assert torch.equal(model.image_embeddings[0], image_features)
+        assert torch.equal(model.text_embeddings[0], text_features)
+        assert torch.equal(
+            model.pas_row_indices[0],
+            metadata["pas_row_index"],
+        )
+
+    def test_validation_step_requires_pas_row_indices(self):
+        """Missing stable row identity fails before metric computation."""
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        metadata = {
+            "image_attr_values": torch.tensor([[1]]),
+            "text_attr_values": torch.tensor([[1]]),
+            "image_accessory_ids": torch.tensor([[1]]),
+            "text_accessory_ids": torch.tensor([[1]]),
+        }
+
+        with pytest.raises(ValueError, match="pas_row_index"):
+            CLIPPlModel.validation_step(
+                model,
+                (torch.eye(1), torch.eye(1), metadata),
+                batch_idx=0,
+            )
+
+    def test_default_validation_preserves_paired_retrieval(self):
+        """Default validation still invokes the existing evaluator."""
+        evaluator = _CaptureEvaluator()
+        model = _validation_model(
+            metadata_match_eval=False,
+            evaluator=evaluator,
+        )
+        model.image_embeddings.append(torch.eye(3))
+        model.text_embeddings.append(torch.eye(3))
+
+        CLIPPlModel.on_validation_epoch_end(model)
+
+        assert evaluator.calls[0]["kwargs"] == {}
+
+    def test_single_rank_pas_validation_matches_shared_evaluator(self):
+        """Training validation uses the shared PAS weighted semantics."""
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        image_rows, text_rows = _pas_row_features()
+        metrics = model._evaluate_accumulated_pas(
+            image_rows,
+            text_rows,
+            torch.arange(len(_pas_pairs())),
+        )
+
+        assert set(metrics) == set(PAS_METADATA_QUERY_TYPES)
+        assert all(value["mAP"] == 1.0 for value in metrics.values())
+        assert all(value["num_queries"] == 2 for value in metrics.values())
+
+        model._log_pas_metrics(metrics, "val")
+        assert [call[0][0] for call in model.logged] == [
+            "val/pas/easy_mAP",
+            "val/pas/medium_mAP",
+            "val/pas/hard_mAP",
+        ]
+
+    def test_multiple_pas_pair_files_load_in_dataloader_order(
+        self, tmp_path, monkeypatch
+    ):
+        """Dataset-specific pairs concatenate in validation-loader order."""
+        pair_files = [
+            tmp_path / "first_pairs.json",
+            tmp_path / "second_pairs.json",
+        ]
+        for pairs_file in pair_files:
+            pairs_file.write_text("[]")
+        datasets = [
+            SimpleNamespace(attribute_pairs_file=str(pairs_file))
+            for pairs_file in pair_files
+        ]
+        expected_by_path = {
+            pair_files[0]: _pas_pairs()[:3],
+            pair_files[1]: _pas_pairs()[3:],
+        }
+        calls = []
+
+        def fake_load_pas_pairs(dataset, pairs_file, ground_truth_mode):
+            calls.append((dataset, pairs_file, ground_truth_mode))
+            return expected_by_path[pairs_file]
+
+        monkeypatch.setattr(
+            pl_clip_model,
+            "load_pas_pairs",
+            fake_load_pas_pairs,
+        )
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        model.pas_validation_datasets = datasets
+        model._pas_validation_pairs = None
+
+        loaded = model._load_pas_validation_pairs()
+
+        assert loaded == _pas_pairs()
+        assert [call[1] for call in calls] == pair_files
+        assert all(
+            call[2] == "scalar_plus_accessories" for call in calls
+        )
+        assert model._load_pas_validation_pairs() is loaded
+        assert len(calls) == 2
+
+    def test_sanity_validation_skips_incomplete_pas_split(self):
+        """Lightning's partial sanity pass does not require full coverage."""
+        model = _validation_model(
+            metadata_match_eval=True,
+            evaluator=_CaptureEvaluator(),
+        )
+        model.image_embeddings.append(torch.eye(1))
+        model.text_embeddings.append(torch.eye(1))
+        model.pas_row_indices.append(torch.tensor([0]))
+        model._evaluate_accumulated_pas = lambda *args: pytest.fail(
+            "PAS evaluation must be skipped during sanity checking"
+        )
+
+        CLIPPlModel.on_validation_epoch_end(model)
+
+        assert model.status_logging_dict == {}
+
+    def test_two_rank_gloo_pas_validation(self, tmp_path):
+        """Uneven rank shards produce identical exact PAS metrics."""
+        init_method = f"file://{tmp_path / 'gloo_init'}"
+        mp.spawn(
+            _run_two_rank_pas_validation,
+            args=(2, init_method),
+            nprocs=2,
+            join=True,
+        )

--- a/tests/multimodal_unit_test/clip/test_scripts.py
+++ b/tests/multimodal_unit_test/clip/test_scripts.py
@@ -5,6 +5,9 @@
 
 import os
 import tempfile
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import h5py
 import numpy as np
@@ -12,6 +15,7 @@ import pytest
 import torch
 from PIL import Image
 
+import nvidia_tao_pytorch.multimodal.clip.scripts.evaluate as evaluate_script
 from nvidia_tao_pytorch.multimodal.clip.scripts.inference import (
     get_image_files,
     load_and_preprocess_batch,
@@ -29,6 +33,177 @@ from nvidia_tao_pytorch.multimodal.clip.scripts.export import (
     ExportFriendlyMHA,
     VALID_ENCODER_TYPES,
 )
+from nvidia_tao_pytorch.multimodal.clip.scripts.train import (
+    _RankLocalDDPStrategy,
+)
+
+
+@pytest.mark.multimodal_unit
+class TestRankLocalDDPSetup:
+    """Test rank-local CUDA and NCCL initialization."""
+
+    def test_ddp_process_group_omits_eager_device_id(self):
+        """NCCL setup should stay lazy after the raw rank-local binding."""
+        timeout = timedelta(seconds=30)
+        cluster_environment = MagicMock()
+        strategy = _RankLocalDDPStrategy(
+            cluster_environment=cluster_environment,
+            timeout=timeout,
+        )
+
+        with (
+            patch.object(strategy, "set_world_ranks"),
+            patch.object(
+                strategy,
+                "_get_process_group_backend",
+                return_value="nccl",
+            ),
+            patch(
+                "nvidia_tao_pytorch.multimodal.clip.scripts.train.reset_seed"
+            ),
+            patch(
+                "nvidia_tao_pytorch.multimodal.clip.scripts.train."
+                "_init_dist_connection"
+            ) as init_dist,
+        ):
+            strategy.setup_distributed()
+
+        init_dist.assert_called_once_with(
+            cluster_environment,
+            "nccl",
+            timeout=timeout,
+        )
+        assert "device_id" not in init_dist.call_args.kwargs
+
+
+@pytest.mark.multimodal_unit
+class TestEvaluateRouting:
+    """Test explicit routing between generic retrieval and direct PAS."""
+
+    @staticmethod
+    def _config(val_datasets, evaluate_datasets):
+        return SimpleNamespace(
+            encryption_key="",
+            model=SimpleNamespace(type="test-model"),
+            dataset=SimpleNamespace(
+                val=SimpleNamespace(datasets=val_datasets),
+            ),
+            evaluate=SimpleNamespace(datasets=evaluate_datasets),
+        )
+
+    def test_validation_pairs_sidecar_stays_on_trainer_test(self, tmp_path):
+        """A validation sidecar must not implicitly select direct PAS."""
+        image_list = tmp_path / "val_list.txt"
+        image_list.write_text("image.jpg\n")
+        (tmp_path / "val_pairs.json").write_text("[]")
+        config = self._config(
+            [
+                SimpleNamespace(
+                    image_dir=str(tmp_path),
+                    caption_dir=str(tmp_path),
+                    image_list_file=str(image_list),
+                )
+            ],
+            [],
+        )
+        model = MagicMock()
+        datamodule = MagicMock()
+        trainer = MagicMock()
+
+        with (
+            patch.object(
+                evaluate_script,
+                "initialize_evaluation_experiment",
+                return_value=(None, {}),
+            ),
+            patch.object(
+                evaluate_script,
+                "CLIPPlModel",
+                return_value=model,
+            ),
+            patch.object(
+                evaluate_script,
+                "CLIPDataModule",
+                return_value=datamodule,
+            ),
+            patch.object(
+                evaluate_script,
+                "Trainer",
+                return_value=trainer,
+            ),
+            patch.object(
+                evaluate_script,
+                "run_pas_evaluation",
+            ) as run_pas,
+        ):
+            evaluate_script.run_experiment(config, key="")
+
+        trainer.test.assert_called_once_with(model, datamodule=datamodule)
+        run_pas.assert_not_called()
+
+    def test_evaluate_datasets_explicitly_selects_direct_pas(self, tmp_path):
+        """An evaluate dataset with a pairs sidecar selects direct PAS."""
+        image_list = tmp_path / "test_list.txt"
+        image_list.write_text("image.jpg\n")
+        pairs_file = tmp_path / "test_pairs.json"
+        pairs_file.write_text("[]")
+        config = self._config(
+            [],
+            [SimpleNamespace(image_list_file=str(image_list))],
+        )
+        model = MagicMock()
+        pairs = [MagicMock()]
+
+        with (
+            patch.object(
+                evaluate_script,
+                "initialize_evaluation_experiment",
+                return_value=(None, {}),
+            ),
+            patch.object(
+                evaluate_script,
+                "CLIPPlModel",
+                return_value=model,
+            ),
+            patch.object(
+                evaluate_script,
+                "resolve_pas_eval_data",
+                return_value=(pairs, pairs_file),
+            ) as resolve_pas,
+            patch.object(
+                evaluate_script,
+                "run_pas_evaluation",
+            ) as run_pas,
+            patch.object(evaluate_script, "Trainer") as trainer_class,
+        ):
+            evaluate_script.run_experiment(config, key="")
+
+        resolve_pas.assert_called_once_with(config, pairs_file)
+        run_pas.assert_called_once_with(config, model, pairs)
+        trainer_class.assert_not_called()
+
+    def test_evaluate_datasets_requires_a_valid_pairs_file(self, tmp_path):
+        """Explicit direct PAS configuration fails instead of falling back."""
+        image_list = tmp_path / "test_list.txt"
+        image_list.write_text("image.jpg\n")
+        config = self._config(
+            [SimpleNamespace(image_list_file=str(image_list))],
+            [SimpleNamespace(image_list_file=str(image_list))],
+        )
+
+        with (
+            patch.object(
+                evaluate_script,
+                "initialize_evaluation_experiment",
+            ) as initialize,
+            pytest.raises(
+                ValueError,
+                match="Direct PAS evaluation was requested",
+            ),
+        ):
+            evaluate_script.run_experiment(config, key="")
+
+        initialize.assert_not_called()
 
 
 @pytest.mark.multimodal_unit

--- a/tests/multimodal_unit_test/clip/test_siglip2_utils.py
+++ b/tests/multimodal_unit_test/clip/test_siglip2_utils.py
@@ -11,6 +11,53 @@ from nvidia_tao_pytorch.multimodal.clip.model.transforms import SigLIP2ImageTran
 
 
 @pytest.mark.multimodal_unit
+class TestSigLIP2BackboneVersions:
+    """Test SigLIP2 backbone version resolution without model downloads."""
+
+    def test_supported_hf_versions_are_mapped(self, monkeypatch):
+        """Test that full SigLIP2 release names resolve to the right HF repos."""
+        from nvidia_tao_pytorch.cv.backbone_v2 import siglip2 as siglip2_module
+
+        seen_sources = []
+        seen_wrapper_args = []
+
+        def fake_from_pretrained(source, trust_remote_code):
+            seen_sources.append((source, trust_remote_code))
+            return object()
+
+        class DummyProcessor:
+            pass
+
+        class DummyWrapper:
+            def __init__(
+                self, model, tokenizer, num_classes, is_dynamic, patch_size
+            ):
+                seen_wrapper_args.append((num_classes, is_dynamic, patch_size))
+
+        monkeypatch.setattr(
+            siglip2_module.AutoModel, "from_pretrained", fake_from_pretrained
+        )
+        monkeypatch.setattr(
+            siglip2_module.AutoProcessor,
+            "from_pretrained",
+            lambda source, trust_remote_code: DummyProcessor(),
+        )
+        monkeypatch.setattr(siglip2_module, "SigLIP2Wrapper", DummyWrapper)
+
+        siglip2_module.get_siglip2_model("siglip2-so400m-patch14-224")
+        siglip2_module.get_siglip2_model("siglip2-so400m-patch16-naflex")
+
+        assert seen_sources == [
+            ("google/siglip2-so400m-patch14-224", True),
+            ("google/siglip2-so400m-patch16-naflex", True),
+        ]
+        assert seen_wrapper_args == [
+            (0, False, 14),
+            (0, True, 16),
+        ]
+
+
+@pytest.mark.multimodal_unit
 class TestSigLIP2ImageTransform:
     """Test SigLIP2ImageTransform class."""
 
@@ -105,3 +152,53 @@ class TestBuildSigLIP2ModelValidation:
         # Error should mention available models
         for model_name in siglip2_model_configs.keys():
             assert model_name in str(exc_info.value)
+
+
+@pytest.mark.multimodal_unit
+class TestBatchHardTripletLoss:
+    """Test auxiliary batch-hard image-text triplet loss."""
+
+    def test_single_sample_batch_returns_zero(self):
+        """Single-sample batches have no negatives, so loss is zero."""
+        from nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model import (
+            _batch_hard_image_text_triplet_loss,
+        )
+
+        image_features = torch.tensor([[1.0, 0.0]])
+        text_features = torch.tensor([[1.0, 0.0]])
+
+        loss = _batch_hard_image_text_triplet_loss(
+            image_features, text_features, margin=0.2
+        )
+
+        assert loss.item() == 0.0
+
+    def test_separated_pairs_have_zero_loss(self):
+        """Perfectly aligned orthogonal pairs satisfy the margin."""
+        from nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model import (
+            _batch_hard_image_text_triplet_loss,
+        )
+
+        image_features = torch.eye(3)
+        text_features = torch.eye(3)
+
+        loss = _batch_hard_image_text_triplet_loss(
+            image_features, text_features, margin=0.2
+        )
+
+        assert torch.isclose(loss, torch.tensor(0.0))
+
+    def test_swapped_pairs_have_positive_loss(self):
+        """Swapped pairs make negatives more similar than positives."""
+        from nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model import (
+            _batch_hard_image_text_triplet_loss,
+        )
+
+        image_features = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        text_features = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+
+        loss = _batch_hard_image_text_triplet_loss(
+            image_features, text_features, margin=0.2
+        )
+
+        assert loss.item() > 0.0

--- a/tests/multimodal_unit_test/clip/test_siglip_loss_dist_impl.py
+++ b/tests/multimodal_unit_test/clip/test_siglip_loss_dist_impl.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SigLIP distributed loss implementation selection."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from open_clip.loss import SigLipLoss
+
+from nvidia_tao_pytorch.config.clip.default_config import CLIPTrainConfig
+from nvidia_tao_pytorch.multimodal.clip.loss.masked_siglip_loss import (
+    MetadataMaskedSigLipLoss,
+)
+from nvidia_tao_pytorch.multimodal.clip.model.pl_clip_model import CLIPPlModel
+
+
+def _build_siglip_loss(
+    dist_impl,
+    world_size=16,
+    rank=3,
+    mask_mode="none",
+    include_attribute_metadata=True,
+    dataset_type="custom",
+):
+    """Build the SigLIP criterion without constructing the full model."""
+    model = SimpleNamespace(
+        loss_type="siglip",
+        siglip_loss_dist_impl=dist_impl,
+        siglip_loss_mask_mode=mask_mode,
+        global_rank=rank,
+        trainer=SimpleNamespace(world_size=world_size),
+        experiment_spec=SimpleNamespace(
+            dataset=SimpleNamespace(
+                train=SimpleNamespace(
+                    include_attribute_metadata=include_attribute_metadata,
+                    type=dataset_type,
+                ),
+            ),
+        ),
+    )
+    CLIPPlModel._build_criterion(model)
+    return model.loss
+
+
+@pytest.mark.multimodal_unit
+class TestSigLipLossDistImpl:
+    """Test SigLIP loss distributed implementation selection."""
+
+    def test_config_defaults_to_gather_and_allows_local(self):
+        """Test default and valid options for SigLIP loss distribution."""
+        field = CLIPTrainConfig.__dataclass_fields__["siglip_loss_dist_impl"]
+
+        assert CLIPTrainConfig().siglip_loss_dist_impl == "gather"
+        assert "local" in field.metadata["valid_options"].split(",")
+        mask_field = CLIPTrainConfig.__dataclass_fields__[
+            "siglip_loss_mask_mode"
+        ]
+        assert "attribute_plus_accessory_match_ignore" in (
+            mask_field.metadata["valid_options"].split(",")
+        )
+
+    def test_local_siglip_loss_uses_single_rank_loss_world(self):
+        """Test local mode disables cross-rank negative exchange."""
+        loss = _build_siglip_loss("local")
+
+        assert isinstance(loss, SigLipLoss)
+        assert loss.dist_impl == "local"
+        assert loss.world_size == 1
+        assert loss.rank == 0
+
+    def test_gather_siglip_loss_uses_trainer_world(self):
+        """Test gather mode keeps the trainer world size."""
+        loss = _build_siglip_loss("gather")
+
+        assert isinstance(loss, SigLipLoss)
+        assert loss.dist_impl == "gather"
+        assert loss.world_size == 16
+        assert loss.rank == 3
+
+    def test_local_masked_siglip_loss_uses_metadata_masked_loss(self):
+        """Test masked SigLIP local mode selects the TAO masked loss."""
+        loss = _build_siglip_loss(
+            "local",
+            mask_mode="attribute_match_ignore",
+        )
+
+        assert isinstance(loss, MetadataMaskedSigLipLoss)
+        assert loss.dist_impl == "local"
+        assert loss.world_size == 1
+
+    def test_gather_masked_siglip_loss_uses_trainer_world(
+        self,
+    ):
+        """Test masked gather mode keeps cross-rank negatives."""
+        loss = _build_siglip_loss(
+            "gather",
+            mask_mode="attribute_match_ignore",
+        )
+
+        assert isinstance(loss, MetadataMaskedSigLipLoss)
+        assert loss.dist_impl == "gather"
+        assert loss.world_size == 16
+        assert loss.rank == 3
+
+    def test_accessory_mask_mode_selects_accessory_aware_loss(self):
+        """Test the new mode enables accessory-aware metadata matching."""
+        loss = _build_siglip_loss(
+            "local",
+            mask_mode="attribute_plus_accessory_match_ignore",
+        )
+
+        assert isinstance(loss, MetadataMaskedSigLipLoss)
+        assert loss.accessory_aware is True
+
+    @pytest.mark.parametrize(
+        "mask_mode",
+        [
+            "attribute_match_ignore",
+            "attribute_plus_accessory_match_ignore",
+        ],
+    )
+    def test_masked_siglip_requires_training_metadata(self, mask_mode):
+        """Test masked loss rejects a dataset that omits batch metadata."""
+        with pytest.raises(
+            ValueError,
+            match="dataset.train.include_attribute_metadata=True",
+        ):
+            _build_siglip_loss(
+                "local",
+                mask_mode=mask_mode,
+                include_attribute_metadata=False,
+            )
+
+    def test_masked_siglip_requires_custom_dataset(self):
+        """Test masked loss rejects loaders that cannot emit metadata."""
+        with pytest.raises(ValueError, match="dataset.train.type='custom'"):
+            _build_siglip_loss(
+                "local",
+                mask_mode="attribute_match_ignore",
+                dataset_type="wds",
+            )
+
+    def test_unmasked_siglip_does_not_require_training_metadata(self):
+        """Test regular SigLIP remains valid without metadata batches."""
+        loss = _build_siglip_loss(
+            "local",
+            include_attribute_metadata=False,
+            dataset_type="wds",
+        )
+
+        assert isinstance(loss, SigLipLoss)
+
+    def test_masked_siglip_loss_rejects_unsupported_distributed_mode(self):
+        """Test masked SigLIP rejects modes without metadata exchange."""
+        with pytest.raises(NotImplementedError, match="local.*gather"):
+            _build_siglip_loss(
+                "bidir",
+                mask_mode="attribute_match_ignore",
+            )
+
+    def test_masked_siglip_backward_requires_metadata(self):
+        """Test masked SigLIP training batches must include metadata."""
+        model = SimpleNamespace(loss=MetadataMaskedSigLipLoss())
+        outputs = (
+            torch.randn(2, 3),
+            torch.randn(2, 3),
+            torch.tensor(1.0),
+            torch.tensor(0.0),
+        )
+
+        with pytest.raises(ValueError, match="requires batch metadata"):
+            CLIPPlModel._backward(model, outputs, batch=(None, None))
+
+    def test_masked_siglip_backward_uses_batch_metadata(self):
+        """Test _backward passes batch metadata into the masked loss."""
+        model = SimpleNamespace(loss=MetadataMaskedSigLipLoss())
+        image_features = torch.tensor([
+            [0.10, 0.20, 0.30],
+            [0.30, 0.20, 0.10],
+        ])
+        text_features = torch.tensor([
+            [0.20, 0.10, 0.30],
+            [0.10, 0.30, 0.20],
+        ])
+        outputs = (
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+        )
+        metadata = {
+            "image_attr_values": torch.tensor([
+                [1, 1],
+                [2, 2],
+            ]),
+            "text_attr_values": torch.tensor([
+                [1, 1],
+                [2, 2],
+            ]),
+        }
+
+        loss, logit_scale, output_image_features, output_text_features = (
+            CLIPPlModel._backward(model, outputs, batch=(None, None, metadata))
+        )
+        expected = model.loss(
+            image_features,
+            text_features,
+            torch.tensor(2.0),
+            torch.tensor(-0.5),
+            image_attr_values=metadata["image_attr_values"],
+            text_attr_values=metadata["text_attr_values"],
+        )
+
+        assert torch.allclose(loss, expected)
+        assert logit_scale is outputs[2]
+        assert output_image_features is image_features
+        assert output_text_features is text_features

--- a/tests/ssl_unit_test/dinov3/__init__.py
+++ b/tests/ssl_unit_test/dinov3/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSL DINOv3 unit tests."""

--- a/tests/ssl_unit_test/dinov3/test_backbone_v2_interop.py
+++ b/tests/ssl_unit_test/dinov3/test_backbone_v2_interop.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 SSL <-> cv/backbone_v2 interop tests.
+
+CPU tests cover the key-rename round-trip and the checkpoint-extraction logic (no GPU, no
+weights). The GPU test is the real gate: an SSL-trained backbone, after ``convert``, loads
+into the existing ``dinov3_vitb16`` registry entry and produces matching features.
+"""
+import os
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
+    timm_to_tao,
+    tao_to_timm,
+    extract_backbone_state_dict,
+    remap_tao_backbone_to_timm,
+    convert_ssl_to_timm,
+)
+
+EMBED = 8
+REG = 4
+
+
+@pytest.mark.ssl_unit
+def test_rename_is_invertible():
+    """timm -> TAO -> timm is the identity on representative keys."""
+    keys = [
+        "cls_token", "reg_token", "patch_embed.proj.weight", "patch_embed.proj.bias",
+        "blocks.0.gamma_1", "blocks.11.gamma_2", "blocks.5.attn.qkv.weight",
+        "blocks.5.attn.proj.bias", "blocks.0.norm1.weight", "blocks.7.mlp.fc1.weight",
+        "norm.weight",
+    ]
+    for k in keys:
+        assert tao_to_timm(timm_to_tao(k)) == k
+
+
+@pytest.mark.ssl_unit
+def test_specific_renames():
+    """The non-identity renames map both directions."""
+    assert timm_to_tao("reg_token") == "register_tokens"
+    assert timm_to_tao("blocks.3.gamma_1") == "blocks.3.ls1.gamma"
+    assert timm_to_tao("blocks.3.gamma_2") == "blocks.3.ls2.gamma"
+    assert tao_to_timm("register_tokens") == "reg_token"
+    assert tao_to_timm("blocks.3.ls1.gamma") == "blocks.3.gamma_1"
+    assert tao_to_timm("blocks.3.ls2.gamma") == "blocks.3.gamma_2"
+    # identity for everything else
+    assert tao_to_timm("blocks.3.attn.qkv.weight") == "blocks.3.attn.qkv.weight"
+
+
+@pytest.mark.ssl_unit
+def test_extract_from_full_lightning_ckpt():
+    """A full checkpoint selects the requested source's backbone and de-prefixes it."""
+    raw = {"state_dict": {
+        "student.backbone.cls_token": torch.zeros(1, 1, EMBED),
+        "teacher.backbone.cls_token": torch.ones(1, 1, EMBED),
+        "student.dino_head.last_layer": torch.zeros(2),
+        "gram_teacher.cls_token": torch.full((1, 1, EMBED), 2.0),
+    }}
+    teacher_sd = extract_backbone_state_dict(raw, source="teacher")
+    assert set(teacher_sd) == {"cls_token"}
+    assert torch.equal(teacher_sd["cls_token"], torch.ones(1, 1, EMBED))
+    student_sd = extract_backbone_state_dict(raw, source="student")
+    assert torch.equal(student_sd["cls_token"], torch.zeros(1, 1, EMBED))
+
+
+@pytest.mark.ssl_unit
+def test_extract_from_stripped_backbone_file():
+    """A stripped backbone file (no prefixes) passes through, dropping stray head keys."""
+    raw = {"cls_token": torch.zeros(1, 1, EMBED), "blocks.0.ls1.gamma": torch.zeros(EMBED)}
+    sd = extract_backbone_state_dict(raw, source="teacher")
+    assert set(sd) == {"cls_token", "blocks.0.ls1.gamma"}
+
+
+@pytest.mark.ssl_unit
+def test_remap_drops_tao_only_and_renames():
+    """remap drops mask_token, renames registers/gammas, keeps the rest."""
+    tao_sd = {
+        "mask_token": torch.zeros(1, 1, EMBED),
+        "register_tokens": torch.zeros(1, REG, EMBED),
+        "blocks.0.ls1.gamma": torch.zeros(EMBED),
+        "cls_token": torch.zeros(1, 1, EMBED),
+    }
+    out = remap_tao_backbone_to_timm(tao_sd)
+    assert "mask_token" not in out
+    assert "reg_token" in out and "blocks.0.gamma_1" in out and "cls_token" in out
+
+
+# ---------------------------------------------------------------------------------------------
+# GPU + weights: the real SSL -> backbone_v2 round-trip gate.
+# ---------------------------------------------------------------------------------------------
+
+_WEIGHT_CANDIDATES = [
+    os.environ.get("DINOV3_VITB_WEIGHTS", ""),
+    "/data/weights/dinov3/vitb16",
+    os.path.expanduser("~/weights/dinov3/vitb16"),
+]
+
+
+def _find_weights():
+    for cand in _WEIGHT_CANDIDATES:
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+_weights = _find_weights()
+requires_weights = pytest.mark.skipif(_weights is None, reason="DINOv3 ViT-B weights not found")
+
+
+def _cosine(a, b):
+    a = a.reshape(-1, a.shape[-1]).float()
+    b = b.reshape(-1, b.shape[-1]).float()
+    return torch.nn.functional.cosine_similarity(a, b, dim=-1).mean().item()
+
+
+@requires_cuda
+@requires_weights
+@pytest.mark.ssl_unit
+def test_ssl_backbone_loads_into_backbone_v2(tmp_path):
+    """Convert an SSL backbone and load it into dinov3_vitb16; features must match."""
+    pytest.importorskip("timm")
+    from nvidia_tao_pytorch.cv.backbone_v2 import BACKBONE_REGISTRY
+    from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer
+    from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+
+    # Build our ViT and load the real DINOv3 weights via the forward (timm->TAO) remap.
+    model = DinoV3VisionTransformer(
+        img_size=256, patch_size=16, embed_dim=768, depth=12, num_heads=12,
+        init_values=1e-5, drop_path_schedule="linear", num_classes=0, drop_path_rate=0.0,
+        register_tokens=4, use_custom_attention=True,
+    )
+    timm_sd = DinoV3PlModel._load_pretrained_state_dict(_weights)
+    remapped, _ = DinoV3PlModel._remap_dinov3_state_dict(timm_sd, model.state_dict())
+    model.load_state_dict(remapped, strict=False)
+
+    # Save a stripped backbone file (TAO naming), then convert to timm layout.
+    stripped = {k: v for k, v in model.state_dict().items()
+                if k != "mask_token" and not k.endswith("rope.periods")}
+    src = str(tmp_path / "teacher_backbone.pth")
+    torch.save(stripped, src)
+    dst = str(tmp_path / "dinov3_vitb_backbone.safetensors")
+    convert_ssl_to_timm(src, dst, source="teacher", validate=True,
+                        timm_model_name="vit_base_patch16_dinov3")
+
+    # Load into the existing backbone_v2 registry entry (strict timm load happens inside).
+    backbone = BACKBONE_REGISTRY.get("dinov3_vitb16")(
+        pretrained_backbone_path=dst, num_classes=0).cuda().half().eval()
+    ours = model.cuda().half().eval()
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 3, 256, 256).cuda().half()
+    with torch.no_grad():
+        cls_v2, _feat_v2 = backbone(x, return_features=True, return_logits=False)
+        out = ours(x)
+
+    cls_cos = _cosine(out["x_norm_clstoken"], cls_v2)
+    assert cls_cos > 0.99, f"CLS cosine after backbone_v2 round-trip too low: {cls_cos}"

--- a/tests/ssl_unit_test/dinov3/test_checkpoint_remap.py
+++ b/tests/ssl_unit_test/dinov3/test_checkpoint_remap.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 checkpoint-remap unit tests: SwiGLU fc1 fuse/split round-trip (ViT-H+/7B)."""
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
+    extract_backbone_state_dict,
+    fuse_timm_swiglu_fc1,
+    is_full_checkpoint,
+    split_fused_swiglu_fc1,
+)
+
+
+def _swiglu_split_state_dict(in_dim=8, hidden=6, n_blocks=2):
+    """Build a tiny timm-style SwiGLU state dict (split fc1_g/fc1_x) plus some non-MLP keys."""
+    sd = {"cls_token": torch.randn(1, 1, in_dim)}
+    for b in range(n_blocks):
+        p = f"blocks.{b}.mlp."
+        sd[p + "fc1_g.weight"] = torch.randn(hidden, in_dim)
+        sd[p + "fc1_g.bias"] = torch.randn(hidden)
+        sd[p + "fc1_x.weight"] = torch.randn(hidden, in_dim)
+        sd[p + "fc1_x.bias"] = torch.randn(hidden)
+        sd[p + "fc2.weight"] = torch.randn(in_dim, hidden)
+        sd[p + "fc2.bias"] = torch.randn(in_dim)
+        sd[f"blocks.{b}.norm1.weight"] = torch.randn(in_dim)  # non-MLP passthrough
+    return sd
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("wrapped", [False, True])
+def test_full_checkpoint_detection_and_teacher_extraction(wrapped):
+    """Full-checkpoint detection and extraction share the same wrapped-state handling."""
+    teacher_weight = torch.ones(1)
+    state_dict = {
+        "student.backbone.cls_token": torch.zeros(1),
+        "teacher.backbone.cls_token": teacher_weight,
+        "teacher.dino_head.weight": torch.randn(1),
+    }
+    checkpoint = {"state_dict": state_dict} if wrapped else state_dict
+
+    assert is_full_checkpoint(checkpoint)
+    extracted = extract_backbone_state_dict(checkpoint, source="teacher")
+    assert set(extracted) == {"cls_token"}
+    assert torch.equal(extracted["cls_token"], teacher_weight)
+
+
+@pytest.mark.ssl_unit
+def test_stripped_checkpoint_is_not_full():
+    """A stripped backbone checkpoint stays on the existing restore path."""
+    checkpoint = {"cls_token": torch.ones(1), "mask_token": torch.zeros(1)}
+
+    assert not is_full_checkpoint(checkpoint)
+    extracted = extract_backbone_state_dict(checkpoint)
+    assert set(extracted) == set(checkpoint)
+    assert all(torch.equal(extracted[key], checkpoint[key]) for key in checkpoint)
+
+
+@pytest.mark.ssl_unit
+def test_swiglu_fc1_fuse_is_gate_first():
+    """Fusing concatenates [fc1_g, fc1_x] along dim 0 (gate first), doubling fc1 width."""
+    torch.manual_seed(0)
+    orig = _swiglu_split_state_dict()
+    fused = fuse_timm_swiglu_fc1(orig)
+
+    # No split projections remain; fused fc1 present at 2x width.
+    assert not any(k.endswith(("fc1_g.weight", "fc1_x.weight")) for k in fused)
+    for b in range(2):
+        p = f"blocks.{b}.mlp."
+        h = orig[p + "fc1_g.weight"].shape[0]
+        for suffix in ("weight", "bias"):
+            assert fused[p + f"fc1.{suffix}"].shape[0] == 2 * h
+            assert torch.equal(fused[p + f"fc1.{suffix}"][:h], orig[p + f"fc1_g.{suffix}"])
+            assert torch.equal(fused[p + f"fc1.{suffix}"][h:], orig[p + f"fc1_x.{suffix}"])
+
+
+@pytest.mark.ssl_unit
+def test_swiglu_fc1_fuse_split_roundtrip():
+    """split(fuse(x)) == x for a SwiGLU checkpoint (load -> export is lossless)."""
+    torch.manual_seed(1)
+    orig = _swiglu_split_state_dict()
+    fused = fuse_timm_swiglu_fc1(orig)
+    # `reference` carries fc1_g keys (ViT-H+/7B target) -> split is applied.
+    restored = split_fused_swiglu_fc1(fused, reference=orig)
+    assert set(restored) == set(orig)
+    for k in orig:
+        assert torch.equal(restored[k], orig[k]), k
+
+
+@pytest.mark.ssl_unit
+def test_swiglu_fc1_split_fuse_roundtrip():
+    """fuse(split(y)) == y starting from a fused checkpoint (export -> load is lossless)."""
+    torch.manual_seed(2)
+    fused = fuse_timm_swiglu_fc1(_swiglu_split_state_dict())
+    refused = fuse_timm_swiglu_fc1(split_fused_swiglu_fc1(fused, reference=_swiglu_split_state_dict()))
+    assert set(refused) == set(fused)
+    for k in fused:
+        assert torch.equal(refused[k], fused[k]), k
+
+
+@pytest.mark.ssl_unit
+def test_plain_mlp_is_untouched():
+    """Plain-MLP (ViT-B/L) ``fc1`` must NOT be split/fused: it has no fc1_g, and a plain-MLP
+    target reference (no fc1_g) leaves the single fc1 intact."""
+    torch.manual_seed(3)
+    plain = {
+        "blocks.0.mlp.fc1.weight": torch.randn(6, 8),
+        "blocks.0.mlp.fc1.bias": torch.randn(6),
+        "blocks.0.mlp.fc2.weight": torch.randn(8, 6),
+        "blocks.0.mlp.fc2.bias": torch.randn(8),
+    }
+    # fuse: no fc1_g in source -> unchanged.
+    fused = fuse_timm_swiglu_fc1(plain)
+    assert set(fused) == set(plain)
+    for k in plain:
+        assert torch.equal(fused[k], plain[k])
+
+    # split: reference has no fc1_g (plain-MLP target) -> fc1 must stay a single tensor.
+    plain_reference = {"blocks.0.mlp.fc1.weight": torch.zeros(6, 8)}
+    split = split_fused_swiglu_fc1(plain, reference=plain_reference)
+    assert set(split) == set(plain)
+    for k in plain:
+        assert torch.equal(split[k], plain[k])

--- a/tests/ssl_unit_test/dinov3/test_config.py
+++ b/tests/ssl_unit_test/dinov3/test_config.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 config unit tests (defaults, param map, inheritance from nvdinov2)."""
+import pytest
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.config.dinov3.default_config import (
+    DINOv3BackboneConfig,
+    DINOv3CuDNNConfig,
+    DINOv3ExportExpConfig,
+    DINOv3TrainExpConfig,
+    DINOv3TransformConfig,
+    ExperimentConfig,
+    map_params,
+    SUPPORTED_BACKBONES,
+    SUPPORTED_IMAGE_SIZES,
+    validate_img_size,
+)
+
+EXPECTED_PRETRAINED_DESCRIPTION = (
+    "Path to DINOv3 pretrained weights matching the configured backbone. "
+    "Accepts a timm-format directory or file, or a stripped TAO DINOv3 "
+    "backbone checkpoint. DINOv2/NVDINOv2 checkpoints are not supported."
+)
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_default_model_name_is_dinov3():
+    """The DINOv3 experiment config defaults its model name to 'dinov3'."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.model_name == "dinov3"
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_pretrained_model_path_description_is_dinov3_specific():
+    """DINOv3 metadata must not inherit the NVDINOv2 checkpoint contract."""
+    field = DINOv3TrainExpConfig.__dataclass_fields__["pretrained_model_path"]
+    assert field.metadata["description"] == EXPECTED_PRETRAINED_DESCRIPTION
+    assert field.metadata["default_value"] is None
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_cudnn_defaults_support_custom_attention():
+    """DINOv3 must not inherit deterministic CuDNN from the common train config."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.train.cudnn.benchmark is True
+    assert cfg.train.cudnn.deterministic is False
+
+    fields = DINOv3CuDNNConfig.__dataclass_fields__
+    assert fields["benchmark"].metadata["description"]
+    assert fields["benchmark"].metadata["display_name"] == "CuDNN benchmark"
+    assert fields["benchmark"].metadata["popular"] == "no"
+    assert fields["deterministic"].metadata["description"]
+    assert fields["deterministic"].metadata["display_name"] == "CuDNN deterministic"
+    assert fields["deterministic"].metadata["popular"] == "no"
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_backbone_patch16_rope_defaults():
+    """DINOv3 backbone defaults: patch-16, 4 register tokens, ViT-B, RoPE theta present."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    bb = cfg.model.backbone
+    assert bb.patch_size == 16
+    assert bb.num_register_tokens == 4
+    assert bb.teacher_type == "vit_b"
+    assert bb.student_type == "vit_b"
+    assert bb.img_size == 256
+    assert SUPPORTED_IMAGE_SIZES == (256, 512, 768)
+    assert bb.rope_theta == 100.0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_validate_img_size_is_public_config_contract():
+    """The shared validator accepts mappings/dataclasses and rejects unsupported values."""
+    for img_size in SUPPORTED_IMAGE_SIZES:
+        validate_img_size({"img_size": img_size})
+
+    backbone_config = DINOv3BackboneConfig(img_size=300)
+    with pytest.raises(
+        ValueError,
+        match=r"model\.backbone\.img_size: 300.*\[256, 512, 768\]",
+    ):
+        validate_img_size(backbone_config)
+    assert ExperimentConfig().model.backbone.img_size == 256
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_gram_and_lora_present():
+    """Gram and (disabled) LoRA configs are present on the model config."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert hasattr(cfg.model, "gram")
+    assert hasattr(cfg.model, "lora")
+    assert cfg.model.lora.enable is False
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_dinov3_256_transform_defaults():
+    """DINOv3 defaults to 256 global crops with patch-16-friendly local crops."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.dataset.transform.global_crops_size == 256
+    assert cfg.dataset.transform.local_crops_size % 16 == 0
+    field = DINOv3TransformConfig.__dataclass_fields__["global_crops_size"]
+    assert field.metadata["description"] == "Size of global crops for DINOv3 training."
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_b():
+    """The v3 param map carries the ViT-B (768/12/12, standard MLP) entry."""
+    assert map_params["embed_dim"]["vit_b"] == 768
+    assert map_params["depth"]["vit_b"] == 12
+    assert map_params["num_heads"]["vit_b"] == 12
+    assert map_params["mlp_layer"]["vit_b"] == "mlp"
+    # ViT-H+ and ViT-7B use SwiGLU.
+    assert map_params["mlp_layer"]["vit_h_plus"] == "swiglu"
+    assert map_params["mlp_layer"]["vit_7b"] == "swiglu"
+    assert set(SUPPORTED_BACKBONES) == {"vit_s", "vit_s_plus", "vit_b", "vit_l", "vit_h_plus", "vit_7b"}
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_l():
+    """The v3 param map carries the ViT-L (1024/24/16, standard GELU MLP) entry (Phase 2)."""
+    assert map_params["embed_dim"]["vit_l"] == 1024
+    assert map_params["depth"]["vit_l"] == 24
+    assert map_params["num_heads"]["vit_l"] == 16
+    assert map_params["mlp_layer"]["vit_l"] == "mlp"
+    # head_dim = 1024 / 16 = 64 (same as ViT-B) -> RoPE (needs head_dim % 4 == 0) works unchanged.
+    assert (map_params["embed_dim"]["vit_l"] // map_params["num_heads"]["vit_l"]) % 4 == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_s():
+    """The v3 param map carries the ViT-S (384/12/6, standard MLP) entry."""
+    assert map_params["embed_dim"]["vit_s"] == 384
+    assert map_params["depth"]["vit_s"] == 12
+    assert map_params["num_heads"]["vit_s"] == 6
+    assert map_params["mlp_layer"]["vit_s"] == "mlp"
+    assert map_params["mlp_ratio"]["vit_s"] == 4.0
+    # head_dim = 384 / 6 = 64 (same as ViT-B/L) -> RoPE (needs head_dim % 4 == 0) works unchanged.
+    assert (map_params["embed_dim"]["vit_s"] // map_params["num_heads"]["vit_s"]) % 4 == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_s_plus():
+    """The v3 param map carries the ViT-S+ (384/12/6, SwiGLU) entry."""
+    assert map_params["embed_dim"]["vit_s_plus"] == 384
+    assert map_params["depth"]["vit_s_plus"] == 12
+    assert map_params["num_heads"]["vit_s_plus"] == 6
+    assert map_params["mlp_layer"]["vit_s_plus"] == "swiglu"
+    assert map_params["mlp_ratio"]["vit_s_plus"] == 4.0
+    assert (map_params["embed_dim"]["vit_s_plus"] // map_params["num_heads"]["vit_s_plus"]) % 4 == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_h_plus():
+    """The v3 param map carries the ViT-H+ (1280/32/20, SwiGLU) entry."""
+    assert map_params["embed_dim"]["vit_h_plus"] == 1280
+    assert map_params["depth"]["vit_h_plus"] == 32
+    assert map_params["num_heads"]["vit_h_plus"] == 20
+    assert map_params["mlp_layer"]["vit_h_plus"] == "swiglu"
+    assert map_params["mlp_ratio"]["vit_h_plus"] == 4.0
+    assert (map_params["embed_dim"]["vit_h_plus"] // map_params["num_heads"]["vit_h_plus"]) % 4 == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_param_map_vit_7b():
+    """The v3 param map carries the ViT-7B (4096/40/32, SwiGLU) entry; the public 7B
+    checkpoint uses the narrow SwiGLU (mlp_ratio 2.0)."""
+    assert map_params["embed_dim"]["vit_7b"] == 4096
+    assert map_params["depth"]["vit_7b"] == 40
+    assert map_params["num_heads"]["vit_7b"] == 32
+    assert map_params["mlp_layer"]["vit_7b"] == "swiglu"
+    assert map_params["mlp_ratio"]["vit_7b"] == 2.0
+    assert (map_params["embed_dim"]["vit_7b"] // map_params["num_heads"]["vit_7b"]) % 4 == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_export_trace_shape_matches_backbone():
+    """Export ONNX trace defaults match the patch-16 backbone (256, not nvdinov2's 518)."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.export.input_width == 256
+    assert cfg.export.input_height == 256
+    assert cfg.export.input_width % cfg.model.backbone.patch_size == 0
+    assert cfg.export.input_height % cfg.model.backbone.patch_size == 0
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_export_checkpoint_contract_selects_teacher():
+    """The generated schema must document deterministic teacher selection for full checkpoints."""
+    field = DINOv3ExportExpConfig.__dataclass_fields__["checkpoint"]
+    assert "full Lightning training checkpoint" in field.metadata["description"]
+    assert "always selects the EMA teacher backbone" in field.metadata["description"]

--- a/tests/ssl_unit_test/dinov3/test_feature_parity.py
+++ b/tests/ssl_unit_test/dinov3/test_feature_parity.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 feature-parity smoke test vs the timm reference (GPU + weights).
+
+Loads the public timm DINOv3 weights into our ``DinoV3VisionTransformer`` via the checkpoint
+remapper and confirms the CLS + patch features are cosine-close to timm's own forward. This
+validates the remapper key/shape coverage AND the RoPE convention end-to-end (rope_theta, coord
+normalization, rotation layout).
+
+Parametrized over architecture x resolution (**ViT-B** @ 256/768, **ViT-L** @ 256); each case
+skips if its weights are not staged. Requires a CUDA GPU (xformers memory-efficient attention).
+Point ``DINOV3_VITB_WEIGHTS`` / ``DINOV3_VITL_WEIGHTS`` at the dir/file if not in a default
+location.
+"""
+import os
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+
+# arch -> timm model name, dims, register count, and where to find the weights.
+_ARCHS = {
+    "vit_b": dict(
+        timm="vit_base_patch16_dinov3", embed_dim=768, depth=12, num_heads=12, registers=4,
+        weights=[os.environ.get("DINOV3_VITB_WEIGHTS", ""),
+                 "/data/weights/dinov3/vitb16", os.path.expanduser("~/weights/dinov3/vitb16")],
+    ),
+    "vit_l": dict(
+        timm="vit_large_patch16_dinov3", embed_dim=1024, depth=24, num_heads=16, registers=4,
+        weights=[os.environ.get("DINOV3_VITL_WEIGHTS", ""),
+                 "/data/weights/dinov3/vitl16", os.path.expanduser("~/weights/dinov3/vitl16")],
+    ),
+}
+
+# (arch, img_size) cases: ViT-B at 256 and the Phase 1 high-res 768; ViT-L at 256.
+# (ViT-L @ 768 is intentionally omitted -- very heavy and not a validated gate.)
+_CASES = [("vit_b", 256), ("vit_b", 768), ("vit_l", 256)]
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+
+
+def _find_weights(candidates):
+    """Return the first existing weights path among the candidates, else None."""
+    for cand in candidates:
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+def _cosine(a, b):
+    """Mean per-row cosine similarity between two ``[..., C]`` tensors (fp32)."""
+    a = a.reshape(-1, a.shape[-1]).float()
+    b = b.reshape(-1, b.shape[-1]).float()
+    return torch.nn.functional.cosine_similarity(a, b, dim=-1).mean().item()
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("arch,img_size", _CASES)
+def test_dinov3_feature_parity_vs_timm(arch, img_size):
+    """Our remapped ViT matches timm's CLS/patch features (cosine > 0.99), per arch and resolution.
+
+    The 768 case (ViT-B) is the Phase 1 gate: it validates that our normalized-coord RoPE
+    extrapolates to a 48x48 grid identically to timm (no pos-embed interpolation).
+    """
+    timm = pytest.importorskip("timm")
+    spec = _ARCHS[arch]
+    weights = _find_weights(spec["weights"])
+    if weights is None:
+        pytest.skip(f"DINOv3 {arch} weights not found")
+
+    ckpt = os.path.join(weights, "model.safetensors") if os.path.isdir(weights) else weights
+    # Keep fp32 master weights and compare under bf16 autocast (mirrors training). Pure .half()
+    # eval overflows the deep ViT-L residual stream (fp16 max ~65504) and yields NaN; bf16 autocast
+    # keeps the residual stream in fp32 range while still exercising the fp16 xformers attention.
+    ref = timm.create_model(
+        spec["timm"], pretrained=False, checkpoint_path=ckpt, img_size=img_size,
+    ).cuda().eval()
+
+    model = DinoV3VisionTransformer(
+        img_size=img_size, patch_size=16, embed_dim=spec["embed_dim"], depth=spec["depth"],
+        num_heads=spec["num_heads"], init_values=1e-5, drop_path_schedule="linear",
+        num_classes=0, drop_path_rate=0.0, register_tokens=spec["registers"],
+        use_custom_attention=True,
+    )
+    # Load via the same remapper the pl_model uses (depth-agnostic; img_size doesn't change keys).
+    timm_sd = DinoV3PlModel._load_pretrained_state_dict(weights)
+    remapped, unmapped = DinoV3PlModel._remap_dinov3_state_dict(timm_sd, model.state_dict())
+    missing, unexpected = model.load_state_dict(remapped, strict=False)
+
+    # Remapper must cover the whole checkpoint and leave only mask_token uninitialized.
+    assert unmapped == [], f"[{arch}] checkpoint keys not mapped: {unmapped}"
+    assert unexpected == [], f"[{arch}] unexpected keys after remap: {unexpected}"
+    assert set(missing) <= {"mask_token"}, f"[{arch}] unexpected missing keys: {missing}"
+
+    model = model.cuda().eval()
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 3, img_size, img_size).cuda()
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+        feats = ref.forward_features(x)
+        np = ref.num_prefix_tokens
+        cls_ref, patch_ref = feats[:, 0], feats[:, np:]
+        out = model(x)
+        cls_ours, patch_ours = out["x_norm_clstoken"], out["x_norm_patchtokens"]
+
+    assert torch.isfinite(cls_ours).all(), f"[{arch}@{img_size}] our CLS features are non-finite"
+    assert torch.isfinite(cls_ref).all(), f"[{arch}@{img_size}] timm CLS features are non-finite"
+
+    cls_cos = _cosine(cls_ours, cls_ref)
+    patch_cos = _cosine(patch_ours, patch_ref)
+    assert cls_cos > 0.99, f"[{arch}@{img_size}] CLS feature cosine too low: {cls_cos}"
+    assert patch_cos > 0.99, f"[{arch}@{img_size}] patch feature cosine too low: {patch_cos}"

--- a/tests/ssl_unit_test/dinov3/test_fp16_stability.py
+++ b/tests/ssl_unit_test/dinov3/test_fp16_stability.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for fp16 (16-mixed) numerical stability on the Blackwell fallback path.
+
+On Blackwell-series GPUs FA3 is unsupported, so ``use_custom_attention`` is forced off and
+attention runs through the naive ``RoPEMemoryEfficientAttention`` fallback. Because DINOv3
+uses ``qk_norm=False`` the raw QK scores are unbounded; with the shipped default
+``train.precision: 16-mixed`` a large-magnitude (pretrained-scale) residual stream drives the
+fp16 score matmul past fp16's 65504 ceiling to ``inf``, and ``softmax(inf) = NaN`` poisons the
+loss. bf16 (val_final ~3.4e38 range) and fp32 do not overflow. See bug 6460915.
+
+The second test guards the reporting side: a non-finite training loss must not be reported as
+a successful run (train_loss is the sole in-loop AutoML KPI).
+"""
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.model.layers.attention import RoPEMemoryEfficientAttention
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+
+# Residual-stream scale large enough that the unnormalized fp16 QK scores exceed fp16's 65504
+# ceiling (stands in for the pretrained-weight activation magnitudes of the real EuroSAT smoke;
+# random-init activations are too small to surface the overflow).
+_OVERFLOW_SCALE = 256.0
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_dinov3_attention_fallback_fp16_finite_under_overflow():
+    """The Blackwell fallback attention must stay finite under 16-mixed autocast.
+
+    Reproduces bug 6460915: with ``qk_norm=False`` and large-magnitude activations the fp16
+    score matmul saturates to ``inf`` and ``softmax(inf)=NaN``. The fallback must compute the
+    scores/softmax in fp32 (as xformers' memory_efficient_attention does internally), so the
+    output stays finite. bf16 is asserted as a control -- it never overflowed.
+    """
+    torch.manual_seed(0)
+    attn = RoPEMemoryEfficientAttention(
+        dim=768, num_heads=12, qkv_bias=False, qk_norm=False, attn_drop=0.0, proj_drop=0.0,
+    ).cuda().eval()
+
+    x = torch.randn(2, 197, 768).cuda() * _OVERFLOW_SCALE
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+        out_bf16 = attn(x, use_custom_attention=False)
+    assert torch.isfinite(out_bf16.float()).all(), "bf16 control unexpectedly non-finite"
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+        out_fp16 = attn(x, use_custom_attention=False)
+    assert torch.isfinite(out_fp16.float()).all(), (
+        "fp16 (16-mixed) fallback attention produced non-finite output -- the unnormalized QK "
+        "score matmul overflowed fp16 (65504) and softmax(inf)=NaN. Compute scores/softmax in fp32."
+    )
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf")])
+def test_dinov3_nonfinite_train_loss_raises(bad_value):
+    """A non-finite epoch train loss must raise (so @monitor_status records FAILURE).
+
+    Regression for the silent-PASS half of bug 6460915: the inherited hook writes train_loss to
+    status.json as the sole in-loop AutoML KPI but never validates it, so a NaN loss was reported
+    as PASS -- hiding the failure from HPO and loss-based milestone selection.
+    """
+    fake = SimpleNamespace(
+        trainer=SimpleNamespace(logged_metrics={"train_loss_epoch": torch.tensor(bad_value)})
+    )
+    with pytest.raises(ValueError, match="non-finite"):
+        DinoV3PlModel._assert_train_loss_finite(fake)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_finite_train_loss_passes():
+    """A finite epoch train loss must not raise."""
+    fake = SimpleNamespace(
+        trainer=SimpleNamespace(logged_metrics={"train_loss_epoch": torch.tensor(10.5)})
+    )
+    DinoV3PlModel._assert_train_loss_finite(fake)  # should not raise

--- a/tests/ssl_unit_test/dinov3/test_gram_highres.py
+++ b/tests/ssl_unit_test/dinov3/test_gram_highres.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 Phase 1 (high-res Gram) unit tests — refresh cadence, grid pooling, config (CPU)."""
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.config.dinov3.default_config import ExperimentConfig
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_gram_phase1_config_fields():
+    """Gram config exposes the Phase 1 knobs with sensible defaults."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.model.gram.refresh_interval == 0      # never refresh -> Phase 0 behavior
+    assert cfg.model.gram.teacher_scale == 1.0       # memory-safe default (paper 2.0; spec may raise)
+    assert cfg.model.gram.teacher_source == "pretrained"
+
+
+@pytest.mark.ssl_unit
+def test_gram_refresh_due():
+    """EMA-refresh fires only at positive multiples of the interval, once per step."""
+    due = DinoV3PlModel._gram_refresh_due
+    assert due(0, 100, -1) is False          # never at step 0
+    assert due(100, 100, -1) is True         # first multiple
+    assert due(100, 100, 100) is False       # already refreshed at 100
+    assert due(150, 100, 100) is False       # not a multiple
+    assert due(200, 100, 100) is True        # next multiple
+    assert due(100, 0, -1) is False          # interval 0 disables
+    assert due(100, -1, -1) is False         # guard against negative
+
+
+@pytest.mark.ssl_unit
+def test_pool_tokens_identity_when_grids_match():
+    """Pooling to the same grid is a no-op."""
+    x = torch.randn(2, 16, 8)
+    out = DinoV3PlModel._pool_tokens(x, (4, 4), (4, 4))
+    assert out.shape == x.shape
+    assert torch.equal(out, x)
+
+
+@pytest.mark.ssl_unit
+def test_pool_tokens_downsamples_grid():
+    """A 4x4 teacher grid average-pools to a 2x2 student grid with the right block means."""
+    C = 3
+    # Build a [1, 4*4, C] grid whose value encodes its (row, col) so we can check block means.
+    grid = torch.zeros(1, 4, 4, C)
+    for r in range(4):
+        for c in range(4):
+            grid[0, r, c, :] = r * 10 + c
+    tokens = grid.reshape(1, 16, C)
+    out = DinoV3PlModel._pool_tokens(tokens, (4, 4), (2, 2))
+    assert out.shape == (1, 4, C)
+    # Top-left 2x2 block: rows {0,1}, cols {0,1} -> values {0,1,10,11} -> mean 5.5
+    assert torch.allclose(out[0, 0], torch.full((C,), 5.5))
+    # Bottom-right 2x2 block: rows {2,3}, cols {2,3} -> {22,23,32,33} -> mean 27.5
+    assert torch.allclose(out[0, 3], torch.full((C,), 27.5))

--- a/tests/ssl_unit_test/dinov3/test_loss.py
+++ b/tests/ssl_unit_test/dinov3/test_loss.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 GramLoss unit tests (CPU; pure-torch, no GPU/xformers needed)."""
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss
+
+BATCH = 2
+N_PATCHES = 16
+CHANNELS = 32
+
+
+@pytest.mark.ssl_unit
+def test_gram_loss_zero_for_identical_inputs():
+    """Identical student/teacher patch tokens give exactly zero Gram loss."""
+    torch.manual_seed(0)
+    x = torch.randn(BATCH, N_PATCHES, CHANNELS)
+    loss = GramLoss()(x, x.clone())
+    assert loss.ndim == 0
+    assert torch.allclose(loss, torch.zeros(()), atol=1e-6)
+
+
+@pytest.mark.ssl_unit
+def test_gram_loss_invariant_to_per_token_scale():
+    """The Gram matrix is cosine-based, so scaling either side per-token is a no-op."""
+    torch.manual_seed(1)
+    student = torch.randn(BATCH, N_PATCHES, CHANNELS)
+    teacher = torch.randn(BATCH, N_PATCHES, CHANNELS)
+    scale = torch.rand(BATCH, N_PATCHES, 1) + 0.5  # strictly positive per-token scale
+    base = GramLoss()(student, teacher)
+    scaled = GramLoss()(student * scale, teacher)
+    assert torch.allclose(base, scaled, atol=1e-5)
+
+
+@pytest.mark.ssl_unit
+def test_gram_loss_positive_for_different_inputs():
+    """Different student/teacher features give a strictly positive loss."""
+    torch.manual_seed(2)
+    student = torch.randn(BATCH, N_PATCHES, CHANNELS)
+    teacher = torch.randn(BATCH, N_PATCHES, CHANNELS)
+    assert GramLoss()(student, teacher) > 0
+
+
+@pytest.mark.ssl_unit
+def test_gram_loss_computes_in_fp32():
+    """fp16 inputs are upcast to fp32 internally; the loss is finite and fp32."""
+    torch.manual_seed(3)
+    student = torch.randn(BATCH, N_PATCHES, CHANNELS, dtype=torch.float16)
+    teacher = torch.randn(BATCH, N_PATCHES, CHANNELS, dtype=torch.float16)
+    loss = GramLoss()(student, teacher)
+    assert loss.dtype == torch.float32
+    assert torch.isfinite(loss)

--- a/tests/ssl_unit_test/dinov3/test_model.py
+++ b/tests/ssl_unit_test/dinov3/test_model.py
@@ -1,0 +1,422 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 model unit tests.
+
+The full-model tests need a CUDA GPU (the inherited nvdinov2 attention uses xformers'
+memory_efficient_attention), so they skip when CUDA is unavailable.
+"""
+import pytest
+from omegaconf import OmegaConf
+import torch
+
+from nvidia_tao_pytorch.config.dinov3.default_config import (
+    ExperimentConfig,
+    SUPPORTED_IMAGE_SIZES,
+    validate_img_size,
+)
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer
+from nvidia_tao_pytorch.ssl.dinov3.model.layers.attention import RoPEMemoryEfficientAttention
+
+BATCH_SIZE = 2
+IMAGE_CHANNEL = 3
+N_GLOBAL_CROPS = 1
+GLOBAL_CROPS_SIZE = 256
+N_LOCAL_CROPS = 1
+LOCAL_CROPS_SIZE = 112
+PATCH_SIZE = 16
+TEACHER_TEMPERATURE = 0.995
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+
+
+def _assert_actionable_checkpoint_error(error, path):
+    """Every invalid-checkpoint failure should identify the field, path, and accepted family."""
+    message = str(error.value)
+    assert "DINOv3 pretrained_model_path" in message
+    assert str(path) in message
+    assert "DINOv2/NVDINOv2 checkpoints are not supported" in message
+
+
+@pytest.fixture
+def _test_batch():
+    torch.manual_seed(47)
+    batch = {}
+    batch["global_crops"] = torch.randn(BATCH_SIZE * N_GLOBAL_CROPS, IMAGE_CHANNEL, GLOBAL_CROPS_SIZE, GLOBAL_CROPS_SIZE)
+    batch["local_crops"] = torch.randn(BATCH_SIZE * N_LOCAL_CROPS, IMAGE_CHANNEL, LOCAL_CROPS_SIZE, LOCAL_CROPS_SIZE)
+    n_tok = (GLOBAL_CROPS_SIZE // PATCH_SIZE) * (GLOBAL_CROPS_SIZE // PATCH_SIZE)
+    batch["global_masks"] = torch.zeros((BATCH_SIZE * N_GLOBAL_CROPS, n_tok), dtype=torch.bool)
+    batch["global_masks_indices"] = batch["global_masks"].flatten().nonzero().flatten()
+    batch["global_masks_weight"] = (
+        1 / batch["global_masks"].float().sum(-1).clamp(min=1.0)
+    ).unsqueeze(-1).expand_as(batch["global_masks"])[batch["global_masks"]]
+    yield batch
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_dinov3_vit_builds_and_forwards():
+    """The v3 ViT-B builds with no absolute pos-embed and runs the single-tensor RoPE forward."""
+    model = DinoV3VisionTransformer(
+        img_size=GLOBAL_CROPS_SIZE, patch_size=PATCH_SIZE, embed_dim=768, depth=12,
+        num_heads=12, init_values=1e-5, drop_path_schedule="linear", num_classes=0,
+        drop_path_rate=0.0, register_tokens=4, use_custom_attention=True,
+    ).cuda().half().eval()
+
+    # DINOv3 drops the absolute positional embedding (RoPE replaces it).
+    assert model.pos_embed is None
+    assert "pos_embed" not in model.state_dict()
+
+    x = torch.randn(BATCH_SIZE, IMAGE_CHANNEL, GLOBAL_CROPS_SIZE, GLOBAL_CROPS_SIZE).cuda().half()
+    with torch.no_grad():
+        out = model(x)
+
+    n_patches = (GLOBAL_CROPS_SIZE // PATCH_SIZE) ** 2
+    assert out["x_norm_clstoken"].shape == (BATCH_SIZE, 768)
+    assert out["x_norm_patchtokens"].shape == (BATCH_SIZE, n_patches, 768)
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_dinov3_backbone_multicrop_finite():
+    """The multi-crop RoPE list path yields finite features in both eval and train modes.
+
+    This is the meaningful check of the new code: RoPE is threaded through the nested
+    ``BlockDiagonalMask`` batching and, with drop_path > 0, the stochastic-depth path in
+    train mode. (Single-tensor eval is covered by ``test_dinov3_vit_builds_and_forwards``.)
+    """
+    backbone = DinoV3VisionTransformer(
+        img_size=GLOBAL_CROPS_SIZE, patch_size=PATCH_SIZE, embed_dim=768, depth=12,
+        num_heads=12, init_values=1e-5, drop_path_schedule="linear", num_classes=0,
+        drop_path_rate=0.4, register_tokens=4, use_custom_attention=True,
+    ).to(torch.float16).cuda()
+
+    gc = torch.randn(BATCH_SIZE, IMAGE_CHANNEL, GLOBAL_CROPS_SIZE, GLOBAL_CROPS_SIZE).half().cuda()
+    lc = torch.randn(BATCH_SIZE, IMAGE_CHANNEL, LOCAL_CROPS_SIZE, LOCAL_CROPS_SIZE).half().cuda()
+    n_tok = (GLOBAL_CROPS_SIZE // PATCH_SIZE) ** 2
+    gm = torch.zeros((BATCH_SIZE, n_tok), dtype=torch.bool).cuda()
+
+    for mode in ("eval", "train"):
+        getattr(backbone, mode)()
+        with torch.no_grad():
+            out = backbone([gc, lc], masks=[gm, None])
+        for crop in out:
+            assert torch.isfinite(crop["x_norm_patchtokens"]).all(), f"non-finite patches in {mode}"
+            assert torch.isfinite(crop["x_norm_clstoken"]).all(), f"non-finite cls in {mode}"
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_dinov3_attention_fallback_matches_xformers():
+    """The non-xformers fallback (used e.g. on Blackwell) must match memory_efficient_attention.
+
+    Regression guard: the fallback previously computed scores over the head axis
+    (``[B, N, H, H]``) instead of the sequence axis, succeeding dimensionally but returning
+    garbage. With ``attn_drop=0`` and identical input the fallback should track the xformers
+    path closely (fp16 tolerance).
+    """
+    torch.manual_seed(0)
+    attn = RoPEMemoryEfficientAttention(
+        dim=768, num_heads=12, qkv_bias=False, qk_norm=False, attn_drop=0.0, proj_drop=0.0,
+    ).cuda().half().eval()
+
+    x = torch.randn(BATCH_SIZE, 197, 768).cuda().half()
+    with torch.no_grad():
+        out_xf = attn(x, use_custom_attention=True)
+        out_fb = attn(x, use_custom_attention=False)
+
+    assert out_fb.shape == out_xf.shape == (BATCH_SIZE, 197, 768)
+    cos = torch.nn.functional.cosine_similarity(
+        out_fb.float().reshape(-1, 768), out_xf.float().reshape(-1, 768), dim=-1
+    ).mean().item()
+    assert cos > 0.99, f"fallback attention diverges from xformers: cosine {cos}"
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_dinov3_model_forward(_test_batch):
+    """Build DinoV3PlModel and run teacher + student forward (nested multi-crop RoPE path).
+
+    Mirrors the nvdinov2 model test's contract: the forward runs end-to-end and returns a
+    scalar loss tensor. Finiteness is not asserted -- on random fp16 inputs with an untrained
+    head and 131072 prototypes the DINO/iBOT/KoLeo terms can legitimately be inf/nan (the
+    nvdinov2 test likewise only checks the forward executes).
+    """
+    experiment_config = OmegaConf.structured(ExperimentConfig())
+
+    model = DinoV3PlModel(experiment_config)
+    model.to(torch.float16).train().cuda()
+
+    # The inherited _extra_losses hook is a no-op for the base/DINOv3 scaffold (Gram added later).
+    assert model._extra_losses() == []
+
+    global_crops = _test_batch["global_crops"].to(torch.float16).cuda()
+    local_crops = _test_batch["local_crops"].to(torch.float16).cuda()
+    global_masks = _test_batch["global_masks"].cuda()
+    global_masks_indices = _test_batch["global_masks_indices"].cuda()
+    global_masks_weight = _test_batch["global_masks_weight"].to(torch.float16).cuda()
+
+    with torch.no_grad():
+        teacher_dino_centered, teacher_ibot_centered, _ = model.teacher_forward(
+            global_crops=global_crops,
+            global_masks_indices=global_masks_indices,
+            teacher_temperature=TEACHER_TEMPERATURE,
+        )
+        loss = model.student_forward(
+            global_crops=global_crops,
+            global_masks=global_masks,
+            global_masks_indices=global_masks_indices,
+            global_masks_weight=global_masks_weight,
+            local_crops=local_crops,
+            teacher_dino_centered=teacher_dino_centered,
+            teacher_ibot_centered=teacher_ibot_centered,
+        )
+    assert isinstance(loss, torch.Tensor) and loss.ndim == 0
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("role", ["teacher_type", "student_type"])
+def test_dinov3_unsupported_backbone_type_raises(role):
+    """An unsupported backbone name must raise a clear ValueError up front, not a KeyError.
+
+    Regression for bug 6460904: the JSON-schema enum (STR_FIELD valid_options) is doc-only, so
+    'vit_h' (not a real TAO DINOv3 arch -- only vit_h_plus exists) passed config validation and
+    died with a bare KeyError deep in model init. Validation now happens before any heavy/CUDA
+    work, so this raises without building the model.
+    """
+    cfg = OmegaConf.structured(ExperimentConfig())
+    setattr(cfg.model.backbone, role, "vit_h")
+    with pytest.raises(ValueError, match="Unsupported model.backbone"):
+        DinoV3PlModel(cfg)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_validate_backbone_types_accepts_supported():
+    """Every advertised architecture passes the up-front backbone validation."""
+    from nvidia_tao_pytorch.config.dinov3.default_config import map_params, SUPPORTED_BACKBONES
+    for name in SUPPORTED_BACKBONES:
+        DinoV3PlModel._validate_backbone_types(
+            {"teacher_type": name, "student_type": name}, map_params
+        )
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_unsupported_img_size_raises_before_model_build():
+    """An out-of-enum image size must fail before model or CUDA initialization."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    cfg.model.backbone.img_size = 300
+
+    with pytest.raises(
+        ValueError,
+        match=r"model\.backbone\.img_size: 300.*\[256, 512, 768\]",
+    ):
+        DinoV3PlModel(cfg)
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("img_size", SUPPORTED_IMAGE_SIZES)
+def test_dinov3_validate_img_size_accepts_supported(img_size):
+    """Every image size advertised by the schema passes runtime validation."""
+    validate_img_size({"img_size": img_size})
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("path_kind", ["missing", "empty_directory"])
+def test_dinov3_pretrained_path_error_is_actionable(tmp_path, path_kind):
+    """Missing paths and empty directories should fail before a low-level loader traceback."""
+    path = tmp_path / path_kind
+    if path_kind == "empty_directory":
+        path.mkdir()
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._load_pretrained_state_dict(path)
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_corrupt_pretrained_file_error_is_actionable(tmp_path):
+    """A corrupt checkpoint should report the configured path and accepted DINOv3 formats."""
+    path = tmp_path / "bad.safetensors"
+    path.write_bytes(b"not a safetensors checkpoint")
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._load_pretrained_state_dict(path)
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_payload_must_be_tensor_state_dict(tmp_path):
+    """A loadable file with the wrong payload type is still not a valid checkpoint."""
+    path = tmp_path / "not-a-state-dict.pth"
+    torch.save(["not", "a", "state", "dict"], path)
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._load_pretrained_state_dict(path)
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_loader_accepts_tensor_state_dict(tmp_path):
+    """A supported file containing a tensor state dict should load unchanged."""
+    path = tmp_path / "model.pth"
+    expected = {"cls_token": torch.randn(1, 1, 4)}
+    torch.save(expected, path)
+
+    loaded = DinoV3PlModel._load_pretrained_state_dict(path)
+    assert set(loaded) == set(expected)
+    assert torch.equal(loaded["cls_token"], expected["cls_token"])
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_loader_preserves_tlt_support(tmp_path):
+    """Inference advertises torch-serialized .tlt checkpoints, so the shared loader accepts them."""
+    path = tmp_path / "model.tlt"
+    expected = {"cls_token": torch.randn(1, 1, 4)}
+    torch.save(expected, path)
+
+    loaded = DinoV3PlModel._load_pretrained_state_dict(path)
+    assert torch.equal(loaded["cls_token"], expected["cls_token"])
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("checkpoint_kind", ["full", "stripped"])
+def test_dinov3_export_restores_teacher_checkpoint(monkeypatch, checkpoint_kind):
+    """Export selects full-checkpoint teacher weights and preserves the stripped path."""
+    from nvidia_tao_pytorch.ssl.dinov3.scripts.export import _restore_export_checkpoint
+
+    student_cls_token = torch.zeros(1, 1, 4)
+    teacher_cls_token = torch.ones(1, 1, 4)
+    if checkpoint_kind == "full":
+        checkpoint = {
+            "student.backbone.cls_token": student_cls_token,
+            "teacher.backbone.cls_token": teacher_cls_token,
+        }
+    else:
+        checkpoint = {"cls_token": teacher_cls_token}
+
+    model = object.__new__(DinoV3PlModel)
+    torch.nn.Module.__init__(model)
+    model.pretrained_weights = "model_epoch_001.pth"
+    model.student = torch.nn.ModuleDict({
+        "backbone": torch.nn.Module(),
+    })
+    model.student.backbone.register_parameter(
+        "cls_token",
+        torch.nn.Parameter(torch.full((1, 1, 4), -1.0)),
+    )
+    model.teacher = torch.nn.ModuleDict({
+        "backbone": torch.nn.Module(),
+    })
+    model.teacher.backbone.register_parameter(
+        "cls_token",
+        torch.nn.Parameter(torch.full((1, 1, 4), -2.0)),
+    )
+    model.model_config = OmegaConf.create({"distill": {"enable": False}})
+
+    loaded_paths = []
+
+    def _load_checkpoint(path):
+        loaded_paths.append(path)
+        return checkpoint
+
+    monkeypatch.setattr(model, "_load_pretrained_state_dict", _load_checkpoint)
+    log_messages = []
+    monkeypatch.setattr(
+        "nvidia_tao_pytorch.ssl.dinov3.model.pl_model.logging.info",
+        log_messages.append,
+    )
+
+    _restore_export_checkpoint(model, model.pretrained_weights)
+
+    assert loaded_paths == [model.pretrained_weights]
+    assert torch.equal(model.teacher.backbone.cls_token, teacher_cls_token)
+    expected_student = (
+        torch.full((1, 1, 4), -1.0)
+        if checkpoint_kind == "full"
+        else teacher_cls_token
+    )
+    assert torch.equal(model.student.backbone.cls_token, expected_student)
+    assert not torch.equal(model.teacher.backbone.cls_token, student_cls_token)
+    if checkpoint_kind == "full":
+        assert any("selected 'teacher.backbone'" in message for message in log_messages)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_validation_rejects_wrong_family(tmp_path):
+    """Absolute positional embeddings identify an unsupported DINOv2-style checkpoint."""
+    path = tmp_path / "dinov2.pth"
+    state_dict = {
+        "cls_token": torch.randn(1, 1, 4),
+        "pos_embed": torch.randn(1, 5, 4),
+    }
+    reference = {"cls_token": torch.zeros(1, 1, 4)}
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._validate_and_remap_pretrained_state_dict(
+            state_dict,
+            reference,
+            path,
+        )
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_validation_wraps_remap_errors(tmp_path):
+    """Malformed SwiGLU pairs should not expose a low-level torch concatenation error."""
+    path = tmp_path / "malformed-swiglu.pth"
+    state_dict = {
+        "blocks.0.mlp.fc1_g.weight": torch.randn(4, 3),
+        "blocks.0.mlp.fc1_x.weight": torch.randn(4, 5),
+    }
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._validate_and_remap_pretrained_state_dict(
+            state_dict,
+            {},
+            path,
+        )
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_validation_requires_backbone_coverage(tmp_path):
+    """Partial or shape-incompatible checkpoints must not silently initialize the rest."""
+    path = tmp_path / "partial.pth"
+    state_dict = {"cls_token": torch.randn(1, 1, 4)}
+    reference = {
+        "cls_token": torch.zeros(1, 1, 4),
+        "patch_embed.proj.weight": torch.zeros(4, 3, 2, 2),
+        "mask_token": torch.zeros(1, 4),
+    }
+
+    with pytest.raises(ValueError) as error:
+        DinoV3PlModel._validate_and_remap_pretrained_state_dict(
+            state_dict,
+            reference,
+            path,
+        )
+    _assert_actionable_checkpoint_error(error, path)
+
+
+@pytest.mark.ssl_unit
+def test_dinov3_pretrained_validation_accepts_matching_timm_keys(tmp_path):
+    """A matching timm state dict may omit only the locally initialized iBOT mask token."""
+    path = tmp_path / "dinov3.pth"
+    state_dict = {
+        "cls_token": torch.randn(1, 1, 4),
+        "reg_token": torch.randn(1, 2, 4),
+    }
+    reference = {
+        "cls_token": torch.zeros(1, 1, 4),
+        "register_tokens": torch.zeros(1, 2, 4),
+        "mask_token": torch.zeros(1, 4),
+    }
+
+    remapped, unmapped = DinoV3PlModel._validate_and_remap_pretrained_state_dict(
+        state_dict,
+        reference,
+        path,
+    )
+    assert set(remapped) == {"cls_token", "register_tokens"}
+    assert not unmapped

--- a/tests/ssl_unit_test/dinov3/test_rope.py
+++ b/tests/ssl_unit_test/dinov3/test_rope.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 2D axial RoPE unit tests (CPU; pure-torch, no GPU/xformers needed).
+
+Covers the rotation math and, critically, that the ``[CLS]`` token and trailing register
+tokens are *not* rotated (identity rows) while patch tokens are.
+"""
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.model.layers.rope import RoPE2D, apply_rope, rotate_half
+
+HEAD_DIM = 64
+NUM_REGISTERS = 4
+
+
+@pytest.mark.ssl_unit
+def test_rotate_half():
+    """rotate_half splits the last dim in half: [a, b] -> [-b, a]."""
+    x = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    out = rotate_half(x)
+    assert torch.equal(out, torch.tensor([-3.0, -4.0, 1.0, 2.0]))
+
+
+@pytest.mark.ssl_unit
+def test_apply_rope_identity_is_noop():
+    """sin=0, cos=1 (the identity rotation) leaves the tensor unchanged."""
+    x = torch.randn(2, 5, 3, HEAD_DIM)
+    sin = torch.zeros(5, HEAD_DIM)
+    cos = torch.ones(5, HEAD_DIM)
+    out = apply_rope(x, sin, cos)
+    assert torch.allclose(out, x, atol=1e-6)
+
+
+@pytest.mark.ssl_unit
+def test_apply_rope_preserves_norm():
+    """RoPE is an orthogonal rotation, so it preserves the per-token vector norm."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 7, 3, HEAD_DIM)
+    # Arbitrary non-trivial angles duplicated across the two halves (rotate_half convention).
+    half = torch.randn(7, HEAD_DIM // 2)
+    emb = torch.cat([half, half], dim=-1)
+    out = apply_rope(x, emb.sin(), emb.cos())
+    assert torch.allclose(out.norm(dim=-1), x.norm(dim=-1), atol=1e-4)
+
+
+@pytest.mark.ssl_unit
+def test_rope2d_excludes_cls_and_registers():
+    """CLS (index 0) and the trailing register rows must be identity; patches must rotate."""
+    H = W = 8
+    rope = RoPE2D(head_dim=HEAD_DIM, theta=100.0, num_prefix_tokens=1,
+                  num_register_tokens=NUM_REGISTERS)
+    sin, cos = rope(H, W, device=torch.device("cpu"), dtype=torch.float32)
+
+    n_patches = H * W
+    seq_len = 1 + n_patches + NUM_REGISTERS
+    assert sin.shape == (seq_len, HEAD_DIM)
+    assert cos.shape == (seq_len, HEAD_DIM)
+
+    # [CLS] at index 0 is identity.
+    assert torch.allclose(sin[0], torch.zeros(HEAD_DIM))
+    assert torch.allclose(cos[0], torch.ones(HEAD_DIM))
+
+    # Trailing register tokens are identity.
+    reg = slice(1 + n_patches, seq_len)
+    assert torch.allclose(sin[reg], torch.zeros(NUM_REGISTERS, HEAD_DIM))
+    assert torch.allclose(cos[reg], torch.ones(NUM_REGISTERS, HEAD_DIM))
+
+    # Patch tokens are rotated: position 0 of the grid has zero angle (still identity), but
+    # later patches must differ from identity.
+    patch = slice(1, 1 + n_patches)
+    assert not torch.allclose(cos[patch], torch.ones(n_patches, HEAD_DIM)), \
+        "patch tokens should carry non-identity rotation"
+
+
+@pytest.mark.ssl_unit
+def test_rope2d_requires_head_dim_divisible_by_four():
+    """2D axial RoPE needs head_dim % 4 == 0 (two axes, rotary pairs each)."""
+    with pytest.raises(AssertionError):
+        RoPE2D(head_dim=66, theta=100.0)
+
+
+@pytest.mark.ssl_unit
+def test_rope2d_grid_distinguishes_positions():
+    """Different patch positions get different rotation tables."""
+    H = W = 4
+    rope = RoPE2D(head_dim=HEAD_DIM, theta=100.0, num_prefix_tokens=1, num_register_tokens=0)
+    sin, cos = rope(H, W, device=torch.device("cpu"), dtype=torch.float32)
+    # patch index 1 (grid (0,1)) vs patch index 5 (grid (1,1)) should differ.
+    assert not torch.allclose(sin[1 + 1], sin[1 + 5])

--- a/tests/ssl_unit_test/dinov3/test_rope_parity.py
+++ b/tests/ssl_unit_test/dinov3/test_rope_parity.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Numerical parity of DINOv3 RoPE2D against timm's RotaryEmbeddingDinoV3 (CPU).
+
+This is the cheap, deterministic guard on the highest-risk piece of the port: the rotary
+frequency schedule, coordinate normalization, and sin/cos layout must match the timm
+``vit_base_patch16_dinov3`` reference exactly. The full feature-parity smoke test
+(``test_feature_parity.py``) needs the weights + a GPU; this one needs neither.
+"""
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.model.layers.rope import RoPE2D
+
+# timm's DINOv3 rope lives in pos_embed_sincos; skip cleanly on older timm.
+timm_rope = pytest.importorskip("timm.layers.pos_embed_sincos")
+RotaryEmbeddingDinoV3 = getattr(timm_rope, "RotaryEmbeddingDinoV3", None)
+requires_timm_rope = pytest.mark.skipif(
+    RotaryEmbeddingDinoV3 is None, reason="timm too old: no RotaryEmbeddingDinoV3"
+)
+
+HEAD_DIM = 64
+THETA = 100.0
+
+
+@requires_timm_rope
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("H,W", [(16, 16), (8, 12)])
+def test_rope2d_matches_timm(H, W):
+    """RoPE2D's patch sin/cos tables equal timm RotaryEmbeddingDinoV3.get_embed."""
+    ref = RotaryEmbeddingDinoV3(
+        dim=HEAD_DIM, temperature=THETA, normalize_coords="separate",
+        grid_indexing="ij", rotate_half=True,
+    ).eval()
+    emb = ref.get_embed((H, W))            # [H*W, 2*head_dim] = cat([sin, cos])
+    sin_ref, cos_ref = emb.chunk(2, dim=-1)  # each [H*W, head_dim]
+
+    rope = RoPE2D(head_dim=HEAD_DIM, theta=THETA, num_prefix_tokens=1, num_register_tokens=4)
+    sin, cos = rope(H, W, device=torch.device("cpu"), dtype=torch.float32)
+
+    # Patch rows live after the single [CLS] prefix; registers are the identity tail.
+    sin_patch = sin[1:1 + H * W]
+    cos_patch = cos[1:1 + H * W]
+
+    assert torch.allclose(sin_patch, sin_ref, atol=1e-5), "RoPE sin table diverges from timm"
+    assert torch.allclose(cos_patch, cos_ref, atol=1e-5), "RoPE cos table diverges from timm"
+
+
+@requires_timm_rope
+@pytest.mark.ssl_unit
+def test_rope2d_periods_match_timm():
+    """The period schedule matches timm's (theta ** (2i / (head_dim/2)))."""
+    ref = RotaryEmbeddingDinoV3(dim=HEAD_DIM, temperature=THETA).eval()
+    rope = RoPE2D(head_dim=HEAD_DIM, theta=THETA)
+    assert torch.allclose(rope.periods, ref.periods, atol=1e-5)

--- a/tests/ssl_unit_test/dinov3/test_sinkhorn.py
+++ b/tests/ssl_unit_test/dinov3/test_sinkhorn.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the Sinkhorn-Knopp centering DINOv3 uses (CPU).
+
+DINOv3 centers teacher outputs with Sinkhorn-Knopp (SwAV) instead of DINOv2's softmax. That
+path in ``DinoV2Loss`` was previously marked untested, so these tests confirm it produces valid
+soft-assignment simplices, stays finite across the spec's teacher-temperature range, and is the
+DINOv3 default. ``DinoHead`` L2-normalizes features against unit-norm prototypes, so teacher
+logits are cosine similarities in ``[-1, 1]`` — the inputs are generated in that range to match.
+"""
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.ssl.nvdinov2.model.loss import DinoV2Loss
+from nvidia_tao_pytorch.config.dinov3.default_config import ExperimentConfig
+
+K = 64    # prototypes
+B = 32    # batch (DINO CLS path)
+P = 900   # masked patch tokens (iBOT path)
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
+def test_dinov3_default_centering_is_sinkhorn():
+    """The DINOv3 config defaults to Sinkhorn-Knopp centering."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    assert cfg.model.centering_method == "sinkhorn"
+
+
+@pytest.mark.ssl_unit
+def test_sinkhorn_produces_valid_simplex():
+    """Sinkhorn output is a non-negative probability simplex per sample (rows sum to 1)."""
+    torch.manual_seed(0)
+    loss = DinoV2Loss(num_prototypes=K, centering_method="sinkhorn")
+    teacher_output = torch.empty(B, K).uniform_(-1, 1)  # cosine-range logits
+    out = loss.centering(teacher_output, teacher_temp=0.04)
+    assert out.shape == (B, K)
+    assert torch.isfinite(out).all(), "sinkhorn produced non-finite values"
+    assert (out >= 0).all(), "sinkhorn produced negative assignments"
+    assert torch.allclose(out.sum(dim=-1), torch.ones(B), atol=1e-4)
+
+
+@pytest.mark.ssl_unit
+def test_sinkhorn_finite_across_teacher_temp_range():
+    """No NaN/inf across the spec's teacher-temp range (0.04 start .. 0.07 base)."""
+    torch.manual_seed(1)
+    loss = DinoV2Loss(num_prototypes=K, centering_method="sinkhorn")
+    teacher_output = torch.empty(B, K).uniform_(-1, 1)
+    for temp in (0.04, 0.07):
+        out = loss.centering(teacher_output, teacher_temp=temp)
+        assert torch.isfinite(out).all(), f"non-finite at teacher_temp={temp}"
+        assert torch.allclose(out.sum(dim=-1), torch.ones(B), atol=1e-4)
+
+
+@pytest.mark.ssl_unit
+def test_sinkhorn_ibot_patch_shape():
+    """The iBOT path (many masked patch tokens) keeps the simplex property."""
+    torch.manual_seed(2)
+    loss = DinoV2Loss(num_prototypes=K, centering_method="sinkhorn")
+    teacher_output = torch.empty(P, K).uniform_(-1, 1)
+    out = loss.centering(teacher_output, teacher_temp=0.07)
+    assert torch.isfinite(out).all()
+    assert torch.allclose(out.sum(dim=-1), torch.ones(P), atol=1e-4)

--- a/tests/ssl_unit_test/nvdinov2/test_attention_gate.py
+++ b/tests/ssl_unit_test/nvdinov2/test_attention_gate.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for bug 6459926: xformers custom attention crashes on Hopper (SM90A).
+
+The xformers ``memory_efficient_attention`` kernel fails to launch on Hopper (compute
+capability ``(9, x)``) with ``cudaErrorLaunchFailure``, but the old gate only force-disabled
+the custom path on Blackwell (``>= (10, 0)``), so H100 ran the crashing kernel by default.
+The policy now enables the custom path only on pre-Hopper GPUs (``< (9, 0)``). These tests
+freeze that policy with a mocked device capability - no Hopper GPU needed.
+"""
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.config.nvdinov2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+
+
+class _FakeProps:
+    def __init__(self, major, minor):
+        self.major = major
+        self.minor = minor
+
+
+@pytest.fixture
+def _fake_capability(monkeypatch):
+    def _set(major, minor):
+        monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+        monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx=0: _FakeProps(major, minor))
+    return _set
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize(
+    "capability,expected",
+    [
+        ((8, 0), True),    # A100 (validated platform)
+        ((8, 6), True),    # Ampere consumer
+        ((8, 9), True),    # Ada
+        ((9, 0), False),   # H100 SM90A: the 6459926 regression
+        ((10, 0), False),  # Blackwell: FA3 unsupported (pre-existing policy)
+        ((12, 0), False),  # beyond Blackwell
+    ],
+)
+def test_custom_attention_supported_policy(_fake_capability, capability, expected):
+    """The gate enables the xformers custom path only on pre-Hopper GPUs."""
+    _fake_capability(*capability)
+    model = object.__new__(DinoV2PlModel)  # bypass __init__; test the policy in isolation
+    assert model._custom_attention_supported() is expected
+
+
+@pytest.mark.ssl_unit
+def test_custom_attention_supported_no_cuda(monkeypatch):
+    """With no CUDA device to probe, the configured flag is honored (no crash)."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    model = object.__new__(DinoV2PlModel)
+    assert model._custom_attention_supported() is True
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize(
+    "capability,expected",
+    [((8, 0), True), ((9, 0), False), ((10, 0), False)],
+)
+def test_model_use_custom_attention_wiring(_fake_capability, capability, expected):
+    """With use_custom_attention=True in config, the built model honors the capability policy."""
+    _fake_capability(*capability)
+    cfg = OmegaConf.structured(ExperimentConfig())
+    cfg.model.backbone.teacher_type = "vit_s"
+    cfg.model.backbone.student_type = "vit_s"
+    cfg.train.use_custom_attention = True
+    model = DinoV2PlModel(cfg)
+    assert model.use_custom_attention is expected

--- a/tests/ssl_unit_test/nvdinov2/test_dataloader.py
+++ b/tests/ssl_unit_test/nvdinov2/test_dataloader.py
@@ -6,6 +6,7 @@ NVDINOv2 Dataloader Unit Tests
 """
 import os
 import pytest
+import tarfile
 from omegaconf import OmegaConf
 from PIL import Image
 import numpy as np
@@ -13,6 +14,7 @@ import tempfile
 
 from nvidia_tao_pytorch.core.utilities import check_and_create
 from nvidia_tao_pytorch.config.nvdinov2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.ssl.nvdinov2.dataloader.dataset import DinoV2Dataset
 from nvidia_tao_pytorch.ssl.nvdinov2.dataloader.pl_dinov2_data_module import DinoV2DataModule
 
 BATCH_SIZE = 2
@@ -54,5 +56,46 @@ def test_nvdionv2_dataloader(_test_dir_obj, _test_exp_spec):
         assert batch['local_crops'].shape[0] == BATCH_SIZE * _test_exp_spec["dataset"]["transform"]["n_local_crops"], "Incorrect batch size of local crops"
         assert batch['local_crops'].shape[2] == _test_exp_spec["dataset"]["transform"]["local_crops_size"], "Incorrect height of local crops"
         assert batch['local_crops'].shape[3] == _test_exp_spec["dataset"]["transform"]["local_crops_size"], "Incorrect width of local crops"
-    
+
     _test_dir_obj.cleanup()
+
+
+def _dummy_transform(image):
+    return image
+
+
+def _save_test_image(path):
+    test_data = (np.random.rand(1, 1, 3) * 255).astype(np.uint8)
+    Image.fromarray(test_data).save(path)
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_dataset_rejects_archive_images_dir(tmp_path):
+    """Regression test for bug 6460966: images_dir pointing at a .tar.gz archive."""
+    image_path = tmp_path / 'test_0.jpg'
+    _save_test_image(image_path)
+    archive_path = tmp_path / 'images.tar.gz'
+    with tarfile.open(archive_path, 'w:gz') as tar:
+        tar.add(image_path, arcname='test_0.jpg')
+
+    with pytest.raises(ValueError, match='archive'):
+        DinoV2Dataset(root=archive_path, transform=_dummy_transform)
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_dataset_nonexistent_images_dir(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        DinoV2Dataset(root=tmp_path / 'does_not_exist', transform=_dummy_transform)
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_dataset_empty_images_dir(tmp_path):
+    with pytest.raises(ValueError, match='No images found'):
+        DinoV2Dataset(root=tmp_path, transform=_dummy_transform)
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_dataset_extracted_images_dir(tmp_path):
+    _save_test_image(tmp_path / 'test_0.jpg')
+    dataset = DinoV2Dataset(root=tmp_path, transform=_dummy_transform)
+    assert len(dataset) == 1

--- a/tests/ssl_unit_test/nvdinov2/test_model.py
+++ b/tests/ssl_unit_test/nvdinov2/test_model.py
@@ -58,3 +58,35 @@ def test_nvdionv2_model(_test_batch):
             teacher_dino_centered=teacher_dino_centered,
             teacher_ibot_centered=teacher_ibot_centered,
         )
+
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+
+
+@requires_cuda
+@pytest.mark.ssl_unit
+def test_nvdinov2_attention_fallback_fp16_finite_under_overflow():
+    """The shared non-xformers fallback (used on Blackwell) stays finite under 16-mixed autocast.
+
+    Regression for bug 6460915: with qk_norm=False and large-magnitude activations the fp16 score
+    matmul saturates to inf and softmax(inf)=NaN. The base MemoryEfficientAttention._fallback_attention
+    must compute the scores/softmax in fp32 so both nvdinov2 and dinov3 stay finite on Blackwell.
+    """
+    from nvidia_tao_pytorch.ssl.nvdinov2.model.layers.attention import MemoryEfficientAttention
+    torch.manual_seed(0)
+    attn = MemoryEfficientAttention(
+        dim=768, num_heads=12, qkv_bias=False, qk_norm=False, attn_drop=0.0, proj_drop=0.0,
+    ).cuda().eval()
+
+    x = torch.randn(2, 197, 768).cuda() * 256.0  # overflow-scale (stands in for pretrained magnitudes)
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.bfloat16):
+        out_bf16 = attn(x, use_custom_attention=False)
+    assert torch.isfinite(out_bf16.float()).all(), "bf16 control unexpectedly non-finite"
+
+    with torch.no_grad(), torch.autocast("cuda", dtype=torch.float16):
+        out_fp16 = attn(x, use_custom_attention=False)
+    assert torch.isfinite(out_fp16.float()).all(), (
+        "fp16 (16-mixed) base fallback attention produced non-finite output -- the unnormalized QK "
+        "score matmul overflowed fp16 (65504) and softmax(inf)=NaN. Compute scores/softmax in fp32."
+    )

--- a/tests/ssl_unit_test/nvdinov2/test_trainer.py
+++ b/tests/ssl_unit_test/nvdinov2/test_trainer.py
@@ -74,3 +74,136 @@ def test_trainer_fit(_test_dir_obj, _test_exp_spec):
     trainer.fit(model, dm, ckpt_path=None)
 
     _test_dir_obj.cleanup()
+
+
+@pytest.mark.ssl_unit
+def test_collate_predictions_multi_gpu_flattens_and_pairs():
+    """Multi-GPU predict collation flattens [world, N, D] and pairs each row with its path.
+
+    Regression for bug 6469109: the old code never reshaped the all_gather'd [world, N, D]
+    feature tensor (so it emitted one row per RANK) and never actually gathered the string
+    paths, producing mismatched column lengths that crashed/hung rank 0 with no CSV written.
+    """
+    feat = torch.arange(2 * 3 * 4, dtype=torch.float32).reshape(2, 3, 4)  # [world=2, N=3, D=4]
+    paths = [["a.jpg", "b.jpg", "c.jpg"], ["d.jpg", "e.jpg", "f.jpg"]]     # per-rank lists
+    rows = DinoV2PlModel._collate_predictions(feat, paths, distributed=True)
+
+    assert [r["input_path"] for r in rows] == ["a.jpg", "b.jpg", "c.jpg", "d.jpg", "e.jpg", "f.jpg"]
+    flat = feat.reshape(-1, 4)
+    assert [r["features"] for r in rows] == [str(flat[i].tolist()) for i in range(6)]
+
+
+@pytest.mark.ssl_unit
+def test_collate_predictions_single_gpu():
+    """Single-device collation yields one row per sample (no world axis)."""
+    feat = torch.arange(3 * 4, dtype=torch.float32).reshape(3, 4)
+    paths = ["a.jpg", "b.jpg", "c.jpg"]
+    rows = DinoV2PlModel._collate_predictions(feat, paths, distributed=False)
+    assert [r["input_path"] for r in rows] == paths
+    assert [r["features"] for r in rows] == [str(feat[i].tolist()) for i in range(3)]
+
+
+@pytest.mark.ssl_unit
+def test_collate_predictions_dedupes_sampler_padding():
+    """Duplicate paths from the predict DistributedSampler's padding collapse to one row each."""
+    feat = torch.arange(2 * 2 * 4, dtype=torch.float32).reshape(2, 2, 4)
+    paths = [["a.jpg", "b.jpg"], ["c.jpg", "a.jpg"]]  # rank 1 padded by repeating 'a.jpg'
+    rows = DinoV2PlModel._collate_predictions(feat, paths, distributed=True)
+    assert [r["input_path"] for r in rows] == ["a.jpg", "b.jpg", "c.jpg"]  # one row per image
+
+
+def _predict_gather_worker(rank, world_size, init_file, ret_dict):
+    """gloo worker: run the real gather + collate that fixes the multi-GPU predict hang."""
+    import torch.distributed as dist
+    from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+    dist.init_process_group("gloo", rank=rank, world_size=world_size, init_method=f"file://{init_file}")
+    try:
+        n, d = 3, 4
+        feat = torch.arange(rank * n * d, (rank + 1) * n * d, dtype=torch.float32).reshape(n, d)
+        # rank 1's last entry repeats rank 0's first path -> mimics the DistributedSampler padding.
+        paths = ["a.jpg", "b.jpg", "c.jpg"] if rank == 0 else ["d.jpg", "e.jpg", "a.jpg"]
+        gathered_feat, paths_per_rank = DinoV2PlModel._all_gather_predictions(feat, paths, world_size)
+        if rank == 0:
+            rows = DinoV2PlModel._collate_predictions(gathered_feat, paths_per_rank, distributed=True)
+            ret_dict["paths"] = [r["input_path"] for r in rows]
+        dist.barrier()  # both ranks reach here iff no collective desynced
+        if rank == 0:
+            ret_dict["both_returned"] = True
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.ssl_unit
+def test_predict_gather_two_process_gloo(tmp_path):
+    """2-process gloo run of the actual on_predict_epoch_end collective + collate.
+
+    Regression for bug 6469109: asserts (a) both ranks return without hanging and (b) rank 0
+    assembles one row per unique image across ranks (sampler-padding duplicate dropped). This is
+    the only test that would catch a re-desync of the multi-GPU predict path.
+    """
+    import time
+    import torch.multiprocessing as mp
+    mgr = mp.Manager()
+    ret = mgr.dict()
+    ctx = mp.spawn(
+        _predict_gather_worker,
+        args=(2, str(tmp_path / "pg_init"), ret),
+        nprocs=2, join=False,
+    )
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if ctx.join(timeout=2):  # returns True once all ranks joined; raises if one errored
+            break
+    else:
+        for p in ctx.processes:
+            p.terminate()
+        pytest.fail("multi-GPU predict gather hung -- ranks desynced (bug 6469109 regression)")
+
+    assert ret.get("both_returned") is True
+    assert sorted(ret["paths"]) == ["a.jpg", "b.jpg", "c.jpg", "d.jpg", "e.jpg"]  # one row per image
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf")])
+def test_nvdinov2_nonfinite_train_loss_raises(bad_value):
+    """A non-finite epoch train loss must raise so @monitor_status records FAILURE.
+
+    Regression for the silent-PASS bug (6460915): train_loss is the sole in-loop AutoML KPI,
+    written to status.json but previously never validated, so a NaN loss was reported as PASS.
+    The guard lives on the shared base, so every SSL model (nvdinov2, dinov3, ...) inherits it.
+    """
+    from types import SimpleNamespace
+    fake = SimpleNamespace(
+        trainer=SimpleNamespace(logged_metrics={"train_loss_epoch": torch.tensor(bad_value)})
+    )
+    with pytest.raises(ValueError, match="non-finite"):
+        DinoV2PlModel._assert_train_loss_finite(fake)
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_finite_train_loss_passes():
+    """A finite epoch train loss must not raise."""
+    from types import SimpleNamespace
+    fake = SimpleNamespace(
+        trainer=SimpleNamespace(logged_metrics={"train_loss_epoch": torch.tensor(10.5)})
+    )
+    DinoV2PlModel._assert_train_loss_finite(fake)  # should not raise
+
+
+@pytest.mark.ssl_unit
+def test_nvdinov2_unsupported_backbone_type_raises():
+    """The shared backbone-name validator raises a clear ValueError on an unsupported arch.
+
+    Regression for bug 6460904: lives on the base so every SSL family inherits it. Uses the
+    subclass's own param_map (its keys are the supported archs) as the single source of truth.
+    """
+    from nvidia_tao_pytorch.config.nvdinov2.default_config import map_params
+    good = sorted(map_params["depth"].keys())[0]
+    with pytest.raises(ValueError, match="Unsupported model.backbone"):
+        DinoV2PlModel._validate_backbone_types(
+            {"teacher_type": good, "student_type": "not_a_real_arch"}, map_params
+        )
+    # A fully-supported pair must not raise.
+    DinoV2PlModel._validate_backbone_types(
+        {"teacher_type": good, "student_type": good}, map_params
+    )


### PR DESCRIPTION
Brings the excluded `tests/` suite and dev config public from GitLab `release/7.1.0`, part of migrating everything (minus CI) to GitHub. Not included: CI, pyarmor, submodules/third_party/tools, public-specific lint/hooks config. Source/entrypoints untouched → telemetry guard intact.