### PR TITLE
Sync tools/ to match GitLab (full migration)

### DIFF
--- a/tools/dataclass_to_rst/README.md
+++ b/tools/dataclass_to_rst/README.md
@@ -1,0 +1,24 @@
+# Instructions to generate RST Tables from Dataclasses
+
+## Steps
+1. Run the following command to generate the RST file from the dataclass file:
+    ```
+    python dataclass_to_rst.py <module_path> <output_file>
+    ```
+2. You can use `python dataclass_to_rst.py -h` to get the list of available command line arguments.
+    ```
+    usage: dataclass_to_rst_tables.py [-h] [--metadata [METADATA ...]] module_path output_file
+
+    Process a dataclass and export to an RST file.
+
+    positional arguments:
+    module_path           Dotted path to the module (e.g., nvidia_tao_core.config.re_identification.default_config)
+    output_file           Output file path (e.g., experiment_config.rst)
+
+    options:
+    -h, --help            show this help message and exit
+    --metadata [METADATA ...]
+                            Optional metadata fields to include (e.g., math_cond, required, popular, etc.)
+    ```
+3. The RST file will be generated in the specified output file path
+4. Optional paratemers can be added to the rst file by specifying them in the command line arguments. Use `--metadata <metadata>` to add metadata to the RST file.

--- a/tools/dataclass_to_rst/dataclass_to_rst_tables.py
+++ b/tools/dataclass_to_rst/dataclass_to_rst_tables.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Original source taken from https://github.com/NVIDIA/NeMo
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility tool to generate an RST tables from a dataclass."""
+
+import argparse
+from dataclasses import fields, is_dataclass
+from collections import deque
+from tabulate import tabulate
+from nvidia_tao_core.api_utils.dataclass2json_converter import import_module_from_path
+
+def format_metadata(metadata):
+    """
+    Formats the metadata of a field.
+
+    :param metadata: Metadata dictionary of a field.
+    :return: Formatted metadata dictionary.
+    """
+    return {k: v for k, v in metadata.items()}
+
+def extract_field_data(field):
+    """
+    Extracts data from a dataclass field.
+
+    :param field: A field from a dataclass.
+    :return: Dictionary containing the field's name, type, and metadata.
+    """
+    field_data = {
+        "name": field.name,
+        "type": str(field.type),
+        "metadata": format_metadata(field.metadata),
+    }
+    return field_data
+
+def process_dataclass(dataclass, q, all_metadata_keys):
+    """
+    Processes a dataclass to extract and format its fields into an RST table.
+
+    :param dataclass: The dataclass to process.
+    :param q: A deque for managing nested dataclasses.
+    :param all_metadata_keys: List of metadata keys to include.
+    :return: Formatted RST table string.
+    """
+    field_names = ["Field"] + all_metadata_keys
+    table_data = []
+
+    for field in fields(dataclass):
+        field_data = extract_field_data(field)
+        row_data = [f":code:`{field_data['name']}`"]
+        for key in all_metadata_keys:
+            row_data.append(field_data["metadata"].get(key, ""))
+        table_data.append(row_data)
+
+        if is_dataclass(field.type):
+            q.append(field.type)
+
+    table = tabulate(table_data, headers=field_names, tablefmt="grid")
+    return table + "\n\n"
+
+def iterate_dataclass_fields(dataclass, all_metadata_keys):
+    """
+    Iterates over the fields of a dataclass and its nested dataclasses to create a full RST table.
+
+    :param dataclass: The root dataclass to process.
+    :param all_metadata_keys: List of metadata keys to include.
+    :return: Full formatted RST table string for all dataclass fields.
+    """
+    q = deque()
+    q.append(dataclass)
+
+    table = ""
+    while len(q) > 0:
+        current_dataclass = q.popleft()
+        table_header = f"\n{current_dataclass.__name__} Fields"
+        header_line = "=" * len(table_header)
+        table += f"{table_header}\n{header_line}\n\n"
+        table += process_dataclass(current_dataclass, q, all_metadata_keys)
+    return table
+
+def write_to_rst_file(dataclass, file_path, all_metadata_keys):
+    """
+    Writes the RST table of a dataclass's fields to a file.
+
+    :param dataclass: The dataclass to process.
+    :param file_path: Path to the output RST file.
+    :param all_metadata_keys: List of metadata keys to include.
+    """
+    rst_content = iterate_dataclass_fields(dataclass, all_metadata_keys)
+    with open(file_path, "w") as file:
+        file.write(rst_content)
+
+def main():
+    """
+    Main function to parse command-line arguments and generate an RST file for a dataclass.
+
+    Command-line Arguments:
+        module_path (str): Dotted path to the module (e.g., nvidia_tao_core.config.re_identification.default_config).
+        output_file (str): Output file path (e.g., experiment_config.rst).
+        --metadata (str): Optional metadata fields to include.
+
+    """
+    parser = argparse.ArgumentParser(description='Process a dataclass and export to an RST file.')
+    parser.add_argument('module_path', type=str, help='Dotted path to the module (e.g., nvidia_tao_core.config.re_identification.default_config)')
+    parser.add_argument('output_file', type=str, help='Output file path (e.g., experiment_config.rst)')
+    parser.add_argument('--metadata', type=str, nargs='*', help='Optional metadata fields to include (e.g., math_cond, required, popular, etc.)')
+
+    args = parser.parse_args()
+
+    all_metadata_keys = [
+        "value_type",
+        "description",
+        "default_value",
+        "valid_min",
+        "valid_max",
+        "valid_options",
+        "automl_enabled",
+    ]
+
+    if args.metadata:
+        all_metadata_keys.extend(args.metadata)
+
+    print("Importing module...")
+    imported_module = import_module_from_path(args.module_path)
+    print(f"Writing to {args.output_file}...")
+    write_to_rst_file(imported_module.ExperimentConfig, args.output_file, all_metadata_keys)
+    print("Done!")
+
+if __name__ == "__main__":
+    main()

--- a/tools/update_readme_supported_commands.py
+++ b/tools/update_readme_supported_commands.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Update README supported-command documentation from setup.py entrypoints."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README_PATH = REPO_ROOT / "README.md"
+SETUP_PATH = REPO_ROOT / "setup.py"
+BEGIN_MARKER = "<!-- BEGIN GENERATED: supported-commands -->"
+END_MARKER = "<!-- END GENERATED: supported-commands -->"
+SPECIAL_CATEGORIES = {
+    "bevfusion": "3D / point cloud",
+    "sparse4d": "3D / point cloud",
+}
+CATEGORY_BY_PACKAGE_ROOT = {
+    "cv": "Computer vision",
+    "multimodal": "Multimodal",
+    "pointcloud": "3D / point cloud",
+    "sdg": "Synthetic data generation",
+    "ssl": "Self-supervised learning",
+}
+CATEGORY_ORDER = [
+    "Computer vision",
+    "3D / point cloud",
+    "Multimodal",
+    "Self-supervised learning",
+    "Synthetic data generation",
+]
+
+
+@dataclass(frozen=True)
+class Command:
+    """Installed TAO command and its backing package."""
+
+    name: str
+    module: str
+    package: str
+    category: str
+    subtasks: tuple[str, ...]
+
+
+def _literal_console_scripts(setup_path: Path) -> list[str]:
+    """Read console_scripts literals from setup.py without importing it."""
+    tree = ast.parse(setup_path.read_text(encoding="utf-8"), filename=str(setup_path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "setup"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "setuptools"
+        ):
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "entry_points" or not isinstance(keyword.value, ast.Dict):
+                continue
+            for key, value in zip(keyword.value.keys, keyword.value.values):
+                if not (
+                    isinstance(key, ast.Constant)
+                    and key.value == "console_scripts"
+                    and isinstance(value, ast.List)
+                ):
+                    continue
+                return [
+                    item.value
+                    for item in value.elts
+                    if isinstance(item, ast.Constant) and isinstance(item.value, str)
+                ]
+    raise RuntimeError(f"Could not find entry_points['console_scripts'] in {setup_path}")
+
+
+def _package_from_entrypoint(module: str) -> str:
+    """Convert an entrypoint module path to the owning model package."""
+    marker = ".entrypoint."
+    if marker not in module:
+        raise ValueError(f"Entrypoint module does not contain {marker!r}: {module}")
+    return module.split(marker, maxsplit=1)[0]
+
+
+def _category(command_name: str, package: str) -> str:
+    """Assign a README category from the command name and package root."""
+    if command_name in SPECIAL_CATEGORIES:
+        return SPECIAL_CATEGORIES[command_name]
+
+    parts = package.split(".")
+    if len(parts) < 2 or parts[0] != "nvidia_tao_pytorch":
+        return "Other"
+    return CATEGORY_BY_PACKAGE_ROOT.get(parts[1], "Other")
+
+
+def _package_to_path(package: str) -> Path:
+    """Convert a Python package name to a repo-local path."""
+    return REPO_ROOT.joinpath(*package.split("."))
+
+
+def _subtasks(package: str) -> tuple[str, ...]:
+    """Discover subtasks from a package's scripts directory."""
+    scripts_dir = _package_to_path(package) / "scripts"
+    subtasks = []
+    if scripts_dir.is_dir():
+        subtasks = [
+            path.stem
+            for path in scripts_dir.glob("*.py")
+            if path.stem != "__init__"
+        ]
+
+    # core.entrypoint.get_subtasks adds default_specs for every registered model.
+    subtasks.append("default_specs")
+    return tuple(sorted(set(subtasks)))
+
+
+def discover_commands(setup_path: Path) -> list[Command]:
+    """Discover installed model-family commands from setup.py."""
+    commands = []
+    for item in _literal_console_scripts(setup_path):
+        command_name, target = item.split("=", maxsplit=1)
+        module = target.split(":", maxsplit=1)[0]
+        package = _package_from_entrypoint(module)
+        commands.append(
+            Command(
+                name=command_name,
+                module=module,
+                package=package,
+                category=_category(command_name, package),
+                subtasks=_subtasks(package),
+            )
+        )
+    return sorted(commands, key=lambda command: command.name)
+
+
+def _code_list(items: list[str] | tuple[str, ...]) -> str:
+    return ", ".join(f"`{item}`" for item in items)
+
+
+def render_supported_commands(commands: list[Command]) -> str:
+    """Render the generated README block."""
+    lines = [
+        BEGIN_MARKER,
+        "",
+        "The package installs one console command per model family. Each command discovers",
+        "its available subtasks from that model's `scripts` package. The `default_specs`",
+        "subtask is added by the shared TAO entrypoint for every registered model.",
+        "",
+        "Run this command after adding or removing a model entrypoint:",
+        "",
+        "```sh",
+        "python tools/update_readme_supported_commands.py",
+        "```",
+        "",
+        "| Domain | Commands |",
+        "| :--- | :--- |",
+    ]
+
+    by_category: dict[str, list[str]] = {}
+    for command in commands:
+        by_category.setdefault(command.category, []).append(command.name)
+
+    ordered_categories = [
+        *[category for category in CATEGORY_ORDER if category in by_category],
+        *sorted(category for category in by_category if category not in CATEGORY_ORDER),
+    ]
+    for category in ordered_categories:
+        lines.append(f"| {category} | {_code_list(by_category[category])} |")
+
+    lines.extend([
+        "",
+        "| Command | Package | Subtasks |",
+        "| :--- | :--- | :--- |",
+    ])
+    for command in commands:
+        package = command.package.removeprefix("nvidia_tao_pytorch.")
+        lines.append(
+            f"| `{command.name}` | `{package}` | {_code_list(command.subtasks)} |"
+        )
+
+    lines.extend([
+        "",
+        "For a specific model family, run the command with no subtask or with `-h` to see",
+        "the supported subtasks:",
+        "",
+        "```sh",
+        "depth_net -h",
+        "depth_net train -h",
+        "```",
+        "",
+        END_MARKER,
+    ])
+    return "\n".join(lines)
+
+
+def replace_generated_block(readme_text: str, generated: str) -> str:
+    """Replace the generated supported-command block in README text."""
+    if BEGIN_MARKER not in readme_text or END_MARKER not in readme_text:
+        raise RuntimeError(
+            f"README must contain {BEGIN_MARKER!r} and {END_MARKER!r} markers"
+        )
+    prefix, rest = readme_text.split(BEGIN_MARKER, maxsplit=1)
+    _, suffix = rest.split(END_MARKER, maxsplit=1)
+    return prefix.rstrip() + "\n\n" + generated + suffix
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Regenerate the README supported-command section."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if README.md is not up to date.",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=README_PATH,
+        help="Path to README.md.",
+    )
+    parser.add_argument(
+        "--setup",
+        type=Path,
+        default=SETUP_PATH,
+        help="Path to setup.py.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Update or check the generated README section."""
+    args = parse_args()
+    commands = discover_commands(args.setup)
+    generated = render_supported_commands(commands)
+    readme_text = args.readme.read_text(encoding="utf-8")
+    updated = replace_generated_block(readme_text, generated)
+
+    if args.check:
+        if updated != readme_text:
+            raise SystemExit(
+                "README.md is out of date. Run "
+                "`python tools/update_readme_supported_commands.py`."
+            )
+        print("README.md supported-command section is up to date.")
+        return
+
+    args.readme.write_text(updated, encoding="utf-8")
+    print(f"Updated {args.readme} with {len(commands)} commands.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds pytorch's `tools/` (3 doc-gen scripts) to match GitLab `release/7.1.0`. Source untouched; guard intact. Closes the last non-CI dir excluded by the pytorch sync.