### PR TITLE
[TAO-2148][Feature] RADIO distillation: consume core KNN via re-export shim

### DIFF
--- a/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
+++ b/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
@@ -102,19 +102,19 @@ def write_files(filename: str, write_mode: str, data: dict):
         elif len(data) == 2 and 'right' in data.keys():
             # write both items the data:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]}" + '\n')
 
         elif len(data) == 2 and 'disparity' in data.keys():
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 3:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 4:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}" + '\n')
     f.close()
 
 

--- a/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
+++ b/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
@@ -1,169 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""K-Nearest Neighbors classification for validation metrics."""
+"""KNN classification for distillation validation — re-export shim.
 
-from typing import Tuple
+Dependency inversion (Epic C): the KNN vote math now lives in the shared
+``nvidia_tao_pytorch.core.evaluation.knn`` module (source of truth, consumed by
+the SSL ``evaluate`` action and the vfm-eval harness too). This module is kept as
+a thin back-compatibility shim so existing imports
+(``from ...distillation.knn_classification import knn_top1_accuracy``) keep working
+unchanged. The functions are the exact same implementations that previously lived
+here — relocated, not modified — so distillation KNN-top1 numbers are unchanged.
+"""
 
-import torch
-import torch.distributed as dist
+from nvidia_tao_pytorch.core.evaluation.knn import (  # noqa: F401
+    _get_vote_cls,
+    distributed_topk,
+    knn_predict,
+    knn_top1_accuracy,
+)
 
-
-def _get_vote_cls(
-    max_sim: torch.Tensor,
-    max_ids: torch.Tensor,
-    num_classes: int,
-) -> torch.Tensor:
-    """Weighted majority vote from top-K neighbors.
-
-    Uses temperature-scaled exponential weighting following
-    https://arxiv.org/pdf/1805.01978.pdf, Section 3.4.
-    """
-    # https://arxiv.org/pdf/1805.01978.pdf, Section 3.4 (Also used by DINO)
-    weights = torch.exp(max_sim / 0.07)
-    cls_vec = torch.zeros(
-        weights.shape[0], num_classes, dtype=weights.dtype, device=weights.device,
-    )
-    cls_vec.scatter_add_(dim=1, index=max_ids, src=weights)
-
-    # The predicted ID is the one with the most vote weight
-    vote_id = torch.argmax(cls_vec, dim=1)
-    return vote_id
-
-
-def _pad(tensor: torch.Tensor, dim0: int) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Pad *tensor* along dim-0 to *dim0* and return a validity mask."""
-    valid_mask = torch.ones(dim0, dtype=torch.bool, device=tensor.device)
-    valid_mask[tensor.shape[0]:].fill_(False)
-
-    if tensor.shape[0] == dim0:
-        # If there is no padding to be done, return the original tensor.
-        return tensor, valid_mask
-
-    # Copy valid elements into a new tensor.
-    ret = torch.empty(dim0, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
-    ret[:tensor.shape[0]].copy_(tensor)
-    return ret, valid_mask
-
-
-def _all_to_all(t: torch.Tensor) -> torch.Tensor:
-    # Unroll the world dim into a list of tensors
-    input_tensors = list(t)
-    output_tensors = [torch.empty_like(v) for v in input_tensors]
-    dist.all_to_all(output_tensors, input_tensors)
-    return torch.stack(output_tensors)
-
-
-def distributed_topk(
-    queries: torch.Tensor,
-    keys: torch.Tensor,
-    labels: torch.Tensor,
-    K: int,
-    distributed: bool,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Find top-K nearest neighbors across all ranks.
-
-    Args:
-        queries: ``[Q, C]`` query embeddings (L2-normalized).
-        keys: ``[D, C]`` key embeddings on this rank (L2-normalized).
-        labels: ``[D]`` class labels for *keys*.
-        K: number of nearest neighbors.
-        distributed: whether to use distributed communication.
-
-    Returns:
-        ``(max_sim, max_labels)`` each of shape ``[Q, K]``.
-    """
-    if distributed:
-        world_size = dist.get_world_size()
-        max_queries = torch.tensor(
-            queries.shape[0], dtype=torch.int64, device=queries.device,
-        )
-        dist.all_reduce(max_queries, dist.ReduceOp.MAX)
-        max_queries = max_queries.item()
-
-        queries, valid_mask = _pad(queries, max_queries)
-        all_queries = torch.empty(
-            world_size, queries.shape[0], queries.shape[1],
-            dtype=queries.dtype, device=queries.device,
-        )
-        dist.all_gather_into_tensor(all_queries, queries)
-    else:
-        all_queries = queries.unsqueeze(0)
-        valid_mask = torch.ones(
-            queries.shape[0], dtype=torch.bool, device=queries.device,
-        )
-
-    # all_queries: W,Q,C
-    # keys: D,C
-
-    # W,Q,D
-    similarity = torch.matmul(all_queries, keys.T)
-
-    # W,Q,K
-    max_sim, max_idxs = torch.topk(similarity, k=K, dim=2, largest=True, sorted=False)
-    max_labels = labels[max_idxs.flatten()].reshape_as(max_idxs)
-
-    if distributed:
-        # Queries is the concatenated list of queries for all ranks,
-        # which means that max_sim and max_idxs is AllQueries -> KeysForThisRank
-        # All to all will then rearrange these to QueriesForThisRank -> AllKeys
-        max_sim = _all_to_all(max_sim)
-        max_labels = _all_to_all(max_labels)
-
-    # Reduce the per-rank similarities
-    # N,K*W
-    max_sim = max_sim.permute(1, 2, 0).flatten(1)
-    max_labels = max_labels.permute(1, 2, 0).flatten(1)
-
-    if distributed:
-        max_sim, max_idxs = torch.topk(max_sim, k=K, dim=1, largest=True, sorted=False)
-        max_labels = torch.gather(max_labels, dim=1, index=max_idxs)
-
-    max_sim = max_sim[valid_mask]
-    max_labels = max_labels[valid_mask]
-
-    return max_sim, max_labels
-
-
-def knn_top1_accuracy(
-    train_split_embeddings: torch.Tensor,
-    train_split_labels: torch.Tensor,
-    K: int,
-    output: torch.Tensor,
-    target: torch.Tensor,
-    distributed: bool,
-    num_classes: int = 1000,
-) -> torch.Tensor:
-    """K-NN Top-1 classification accuracy.
-
-    Args:
-        train_split_embeddings: ``[N_train, C]`` L2-normalized training embeddings.
-        train_split_labels: ``[N_train]`` training class labels.
-        K: number of nearest neighbors for majority vote.
-        output: ``[B, C]`` L2-normalized query embeddings.
-        target: ``[B]`` ground-truth class IDs.
-        distributed: whether to use distributed communication.
-        num_classes: total number of classes (default 1000 for ImageNet).
-
-    Returns:
-        Top-1 accuracy as a scalar tensor (percentage, 0–100).
-    """
-    max_sim, max_labels = distributed_topk(
-        queries=output,
-        keys=train_split_embeddings,
-        labels=train_split_labels,
-        K=K,
-        distributed=distributed,
-    )
-
-    # Get a weighted vote for each validation sample.
-    vote_id = _get_vote_cls(max_sim, max_labels, num_classes=num_classes)
-
-    # Compare against ground truth.
-    correct = target == vote_id
-
-    # Get total number of correct predictions and calculate accuracy.
-    num_correct = correct.sum()
-    acc1 = 100.0 * num_correct / output.size(0)
-
-    return acc1
+__all__ = ["_get_vote_cls", "distributed_topk", "knn_predict", "knn_top1_accuracy"]


### PR DESCRIPTION
### What changes are proposed in this pull request?

Dependency inversion for RADIO distillation: `radio/distillation/knn_classification.py` becomes a thin re-export shim onto the shared `core.evaluation.knn` module. The math is relocated, not modified — `validate.py` and the distiller resolve to the same core objects.

### Why are the changes needed?

Part 3/5 of the shared `core/evaluation` embedding-eval suite (epic TAO-2181). Removes a duplicated KNN implementation so SSL and RADIO families evaluate through one code path.

### Related issues

JIRA: TAO-2148 (parent epic TAO-2181). N/A for GitHub issues.

### Does this PR introduce _any_ user-facing change?

No — behavior-preserving refactor; distillation KNN-top1 unchanged.

### How was this patch tested?

Covered by the stack's shared test suite (26 unit tests land in #80, including KNN vote math: FAISS + brute-force + online → 100% on separable data). Distillation KNN-top1 verified unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Yes

### Release note

```release-note
NONE
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

Review the core-eval stack in order: #78 → #79 → #80 → #81 (this is part 3/5; parts 1–2 merged on GitLab before migration).

---
_Migrated from GitLab MR nvidia-tao-toolkit/tao-pytorch!616, rebased onto GitHub `main`._