### PR TITLE
[TAO-2149][Feature] SSL evaluate actions for NV-DINOv2 and MAE (embedding suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python tools/update_readme_supported_commands.py
 | `mask2former` | `cv.mask2former` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `mask_grounding_dino` | `cv.mask_grounding_dino` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `ml_recog` | `cv.ml_recog` | `default_specs`, `evaluate`, `export`, `inference`, `train` |
-| `nvdinov2` | `ssl.nvdinov2` | `default_specs`, `export`, `inference`, `train` |
+| `nvdinov2` | `ssl.nvdinov2` | `default_specs`, `evaluate`, `export`, `inference`, `train` |
 | `ocdnet` | `cv.ocdnet` | `default_specs`, `evaluate`, `export`, `inference`, `prune`, `quantize`, `train` |
 | `ocrnet` | `cv.ocrnet` | `dataset_convert`, `default_specs`, `evaluate`, `export`, `inference`, `prune`, `quantize`, `train` |
 | `oneformer` | `cv.oneformer` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |

--- a/nvidia_tao_pytorch/config/mae/default_config.py
+++ b/nvidia_tao_pytorch/config/mae/default_config.py
@@ -15,6 +15,7 @@ from nvidia_tao_pytorch.config.common.common_config import (
     InferenceConfig,
     TrainConfig,
 )
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import EvalSuiteConfig
 from nvidia_tao_pytorch.config.utils.types import (
     STR_FIELD,
     INT_FIELD,
@@ -373,6 +374,15 @@ class MAEGenTrtEngineConfig(GenTrtEngineConfig):
 
 
 @dataclass
+class MAEEvaluateExpConfig(EvaluateConfig, EvalSuiteConfig):
+    """MAE evaluate config: supervised classification test (default) PLUS the optional
+    shared embedding-quality suite (knn/segmentation/retrieval). When any suite block is
+    enabled, the evaluate action runs the core suite; otherwise the existing classification
+    test path is used.
+    """
+
+
+@dataclass
 class ExperimentConfig(CommonExperimentConfig):
     """Experiment configuration template."""
 
@@ -380,7 +390,7 @@ class ExperimentConfig(CommonExperimentConfig):
     train: MAETrainExpConfig = DATACLASS_FIELD(MAETrainExpConfig())
     model: MAEModelConfig = DATACLASS_FIELD(MAEModelConfig())
     inference: InferenceConfig = DATACLASS_FIELD(InferenceConfig())
-    evaluate: EvaluateConfig = DATACLASS_FIELD(EvaluateConfig())
+    evaluate: MAEEvaluateExpConfig = DATACLASS_FIELD(MAEEvaluateExpConfig())
     gen_trt_engine: MAEGenTrtEngineConfig = DATACLASS_FIELD(MAEGenTrtEngineConfig())
     export: ExportConfig = DATACLASS_FIELD(ExportConfig())
 

--- a/nvidia_tao_pytorch/config/nvdinov2/default_config.py
+++ b/nvidia_tao_pytorch/config/nvdinov2/default_config.py
@@ -9,11 +9,13 @@ from omegaconf import MISSING
 
 from nvidia_tao_pytorch.config.common.common_config import (
     CommonExperimentConfig,
+    EvaluateConfig,
     InferenceConfig,
     TrainConfig,
     GenTrtEngineConfig,
     TrtConfig
 )
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import EvalSuiteConfig
 from nvidia_tao_pytorch.config.utils.types import (
     STR_FIELD,
     INT_FIELD,
@@ -701,6 +703,15 @@ class NVDINOv2ExportExpConfig:
 
 
 @dataclass
+class NVDINOv2EvaluateExpConfig(EvaluateConfig, EvalSuiteConfig):
+    """Evaluate experiment config — embedding-quality suite (KNN; seg/retrieval to come).
+
+    Inherits the common GPU/checkpoint/results fields from ``EvaluateConfig`` and
+    the shared per-metric blocks (``knn``, ``cache_dir``) from ``EvalSuiteConfig``.
+    """
+
+
+@dataclass
 class GenTrtEngineExpConfig(GenTrtEngineConfig):
     """Gen TRT Engine experiment config."""
 
@@ -727,6 +738,12 @@ class ExperimentConfig(CommonExperimentConfig):
         NVDINOv2InferenceExpConfig(),
         description=(
             "Configurable parameters to construct the inference trainer for a NVDINOv2 experiment."
+        ),
+    )
+    evaluate: NVDINOv2EvaluateExpConfig = DATACLASS_FIELD(
+        NVDINOv2EvaluateExpConfig(),
+        description=(
+            "Configurable parameters for the NVDINOv2 evaluate (embedding-quality) action."
         ),
     )
     export: NVDINOv2ExportExpConfig = DATACLASS_FIELD(

--- a/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
+++ b/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
@@ -102,19 +102,19 @@ def write_files(filename: str, write_mode: str, data: dict):
         elif len(data) == 2 and 'right' in data.keys():
             # write both items the data:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]}" + '\n')
 
         elif len(data) == 2 and 'disparity' in data.keys():
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 3:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 4:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}" + '\n')
     f.close()
 
 

--- a/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
+++ b/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
@@ -1,169 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""K-Nearest Neighbors classification for validation metrics."""
+"""KNN classification for distillation validation — re-export shim.
 
-from typing import Tuple
+Dependency inversion (Epic C): the KNN vote math now lives in the shared
+``nvidia_tao_pytorch.core.evaluation.knn`` module (source of truth, consumed by
+the SSL ``evaluate`` action and the vfm-eval harness too). This module is kept as
+a thin back-compatibility shim so existing imports
+(``from ...distillation.knn_classification import knn_top1_accuracy``) keep working
+unchanged. The functions are the exact same implementations that previously lived
+here — relocated, not modified — so distillation KNN-top1 numbers are unchanged.
+"""
 
-import torch
-import torch.distributed as dist
+from nvidia_tao_pytorch.core.evaluation.knn import (  # noqa: F401
+    _get_vote_cls,
+    distributed_topk,
+    knn_predict,
+    knn_top1_accuracy,
+)
 
-
-def _get_vote_cls(
-    max_sim: torch.Tensor,
-    max_ids: torch.Tensor,
-    num_classes: int,
-) -> torch.Tensor:
-    """Weighted majority vote from top-K neighbors.
-
-    Uses temperature-scaled exponential weighting following
-    https://arxiv.org/pdf/1805.01978.pdf, Section 3.4.
-    """
-    # https://arxiv.org/pdf/1805.01978.pdf, Section 3.4 (Also used by DINO)
-    weights = torch.exp(max_sim / 0.07)
-    cls_vec = torch.zeros(
-        weights.shape[0], num_classes, dtype=weights.dtype, device=weights.device,
-    )
-    cls_vec.scatter_add_(dim=1, index=max_ids, src=weights)
-
-    # The predicted ID is the one with the most vote weight
-    vote_id = torch.argmax(cls_vec, dim=1)
-    return vote_id
-
-
-def _pad(tensor: torch.Tensor, dim0: int) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Pad *tensor* along dim-0 to *dim0* and return a validity mask."""
-    valid_mask = torch.ones(dim0, dtype=torch.bool, device=tensor.device)
-    valid_mask[tensor.shape[0]:].fill_(False)
-
-    if tensor.shape[0] == dim0:
-        # If there is no padding to be done, return the original tensor.
-        return tensor, valid_mask
-
-    # Copy valid elements into a new tensor.
-    ret = torch.empty(dim0, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
-    ret[:tensor.shape[0]].copy_(tensor)
-    return ret, valid_mask
-
-
-def _all_to_all(t: torch.Tensor) -> torch.Tensor:
-    # Unroll the world dim into a list of tensors
-    input_tensors = list(t)
-    output_tensors = [torch.empty_like(v) for v in input_tensors]
-    dist.all_to_all(output_tensors, input_tensors)
-    return torch.stack(output_tensors)
-
-
-def distributed_topk(
-    queries: torch.Tensor,
-    keys: torch.Tensor,
-    labels: torch.Tensor,
-    K: int,
-    distributed: bool,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Find top-K nearest neighbors across all ranks.
-
-    Args:
-        queries: ``[Q, C]`` query embeddings (L2-normalized).
-        keys: ``[D, C]`` key embeddings on this rank (L2-normalized).
-        labels: ``[D]`` class labels for *keys*.
-        K: number of nearest neighbors.
-        distributed: whether to use distributed communication.
-
-    Returns:
-        ``(max_sim, max_labels)`` each of shape ``[Q, K]``.
-    """
-    if distributed:
-        world_size = dist.get_world_size()
-        max_queries = torch.tensor(
-            queries.shape[0], dtype=torch.int64, device=queries.device,
-        )
-        dist.all_reduce(max_queries, dist.ReduceOp.MAX)
-        max_queries = max_queries.item()
-
-        queries, valid_mask = _pad(queries, max_queries)
-        all_queries = torch.empty(
-            world_size, queries.shape[0], queries.shape[1],
-            dtype=queries.dtype, device=queries.device,
-        )
-        dist.all_gather_into_tensor(all_queries, queries)
-    else:
-        all_queries = queries.unsqueeze(0)
-        valid_mask = torch.ones(
-            queries.shape[0], dtype=torch.bool, device=queries.device,
-        )
-
-    # all_queries: W,Q,C
-    # keys: D,C
-
-    # W,Q,D
-    similarity = torch.matmul(all_queries, keys.T)
-
-    # W,Q,K
-    max_sim, max_idxs = torch.topk(similarity, k=K, dim=2, largest=True, sorted=False)
-    max_labels = labels[max_idxs.flatten()].reshape_as(max_idxs)
-
-    if distributed:
-        # Queries is the concatenated list of queries for all ranks,
-        # which means that max_sim and max_idxs is AllQueries -> KeysForThisRank
-        # All to all will then rearrange these to QueriesForThisRank -> AllKeys
-        max_sim = _all_to_all(max_sim)
-        max_labels = _all_to_all(max_labels)
-
-    # Reduce the per-rank similarities
-    # N,K*W
-    max_sim = max_sim.permute(1, 2, 0).flatten(1)
-    max_labels = max_labels.permute(1, 2, 0).flatten(1)
-
-    if distributed:
-        max_sim, max_idxs = torch.topk(max_sim, k=K, dim=1, largest=True, sorted=False)
-        max_labels = torch.gather(max_labels, dim=1, index=max_idxs)
-
-    max_sim = max_sim[valid_mask]
-    max_labels = max_labels[valid_mask]
-
-    return max_sim, max_labels
-
-
-def knn_top1_accuracy(
-    train_split_embeddings: torch.Tensor,
-    train_split_labels: torch.Tensor,
-    K: int,
-    output: torch.Tensor,
-    target: torch.Tensor,
-    distributed: bool,
-    num_classes: int = 1000,
-) -> torch.Tensor:
-    """K-NN Top-1 classification accuracy.
-
-    Args:
-        train_split_embeddings: ``[N_train, C]`` L2-normalized training embeddings.
-        train_split_labels: ``[N_train]`` training class labels.
-        K: number of nearest neighbors for majority vote.
-        output: ``[B, C]`` L2-normalized query embeddings.
-        target: ``[B]`` ground-truth class IDs.
-        distributed: whether to use distributed communication.
-        num_classes: total number of classes (default 1000 for ImageNet).
-
-    Returns:
-        Top-1 accuracy as a scalar tensor (percentage, 0–100).
-    """
-    max_sim, max_labels = distributed_topk(
-        queries=output,
-        keys=train_split_embeddings,
-        labels=train_split_labels,
-        K=K,
-        distributed=distributed,
-    )
-
-    # Get a weighted vote for each validation sample.
-    vote_id = _get_vote_cls(max_sim, max_labels, num_classes=num_classes)
-
-    # Compare against ground truth.
-    correct = target == vote_id
-
-    # Get total number of correct predictions and calculate accuracy.
-    num_correct = correct.sum()
-    acc1 = 100.0 * num_correct / output.size(0)
-
-    return acc1
+__all__ = ["_get_vote_cls", "distributed_topk", "knn_predict", "knn_top1_accuracy"]

--- a/nvidia_tao_pytorch/ssl/mae/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/mae/model/pl_model.py
@@ -98,7 +98,7 @@ class MAEPlModule(TAOLightningModule):
         model_arch = self.cfg.model.arch
         supported_archs = [m[len("mae_"):] for m in self.model_mapper.keys()]
         if model_arch not in supported_archs:
-            raise NotImplementedError(f"Only {", ".join(supported_archs)} are supported, but {model_arch} is specified.")
+            raise NotImplementedError(f"Only {', '.join(supported_archs)} are supported, but {model_arch} is specified.")
         self.checkpoint_filename = model_arch
         # Enable the MAE mask for the pretrain stage and if not exporting the model.
         if self.cfg.train.stage == "pretrain" and not self.export:

--- a/nvidia_tao_pytorch/ssl/mae/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/ssl/mae/scripts/evaluate.py
@@ -1,7 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""MAE evaluation script."""
+"""MAE evaluation script.
+
+Two modes, dispatched by config (backward-compatible):
+
+- **Embedding-quality suite** — when any of ``evaluate.{knn,segmentation,retrieval}.enabled``
+  is set, the trained MAE encoder is wrapped in the shared ``core/evaluation`` model
+  adapter and the enabled evaluators run, writing ``results.json`` (same path as the
+  NV-DINOv2 ``evaluate`` action).
+- **Supervised classification test** (default, unchanged) — otherwise the original
+  ``trainer.test`` path runs the finetune-stage classification metrics.
+"""
+import json
 import logging
 import os
 import warnings
@@ -9,6 +20,7 @@ import warnings
 from pytorch_lightning import Trainer
 
 from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.distributed.comm import get_local_rank, is_dist_avail_and_initialized
 from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
 from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
 
@@ -21,6 +33,52 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 logger = logging.getLogger(__name__)
 spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+_SUITE_BLOCKS = ("knn", "segmentation", "retrieval")
+
+
+def _suite_enabled(cfg) -> bool:
+    """True if any embedding-suite evaluator block is enabled in the evaluate config."""
+    ev = cfg.evaluate
+    return any(getattr(getattr(ev, b, None), "enabled", False) for b in _SUITE_BLOCKS)
+
+
+def _run_embedding_suite(cfg, model_path) -> None:
+    """Run the shared embedding-quality suite on the MAE encoder → results.json."""
+    import torch
+
+    from nvidia_tao_pytorch.core.evaluation import (
+        EvalContext, build_adapter, build_enabled_evaluators,
+    )
+    from nvidia_tao_pytorch.core.evaluation.datasets.classification import (
+        build_classification_loader,
+    )
+
+    device = torch.device(
+        f"cuda:{get_local_rank()}" if torch.cuda.is_available() else "cpu")
+    pl_model = MAEPlModule.load_from_checkpoint(model_path, map_location="cpu", cfg=cfg)
+    pl_model = pl_model.to(device).eval()
+
+    adapter = build_adapter("mae", pl_model).to(device)
+    eval_cfg = cfg.evaluate
+    ctx = EvalContext(
+        model=adapter, network="mae", device=device,
+        distributed=is_dist_avail_and_initialized(),
+        build_loader=build_classification_loader, cfg=eval_cfg,
+        results_dir=cfg.results_dir, cache_dir=eval_cfg.cache_dir,
+    )
+
+    results = {}
+    for evaluator in build_enabled_evaluators(eval_cfg):
+        logger.info("Running evaluator: %s", evaluator.name)
+        results.update(evaluator.run(ctx))
+
+    if get_local_rank() == 0:
+        os.makedirs(cfg.results_dir, exist_ok=True)
+        out_path = os.path.join(cfg.results_dir, "results.json")
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2)
+        logger.info("Wrote %s: %s", out_path, results)
+
 
 @hydra_runner(
     config_path=os.path.join(spec_root, "experiment_specs"),
@@ -28,21 +86,22 @@ spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 @monitor_status(name="MAE", mode="evaluate")
 def run_experiment(cfg: ExperimentConfig) -> None:
-    """Run training experiment."""
+    """Run MAE evaluation (embedding suite if enabled, else classification test)."""
     model_path, trainer_kwargs = initialize_evaluation_experiment(cfg)
+
+    if _suite_enabled(cfg):
+        logger.info("Running embedding-quality evaluation suite...")
+        _run_embedding_suite(cfg, model_path)
+        return
 
     logger.info("Setting up dataloader...")
     data_module = MAEDataModule(cfg=cfg)
 
     logger.info("Building MAE models...")
-
     pl_model = MAEPlModule.load_from_checkpoint(
-        model_path,
-        map_location="cpu",
-        cfg=cfg)
+        model_path, map_location="cpu", cfg=cfg)
 
     trainer = Trainer(**trainer_kwargs)
-
     trainer.test(pl_model, data_module)
 
 

--- a/nvidia_tao_pytorch/ssl/nvdinov2/experiment_specs/evaluate_spec.yaml
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/experiment_specs/evaluate_spec.yaml
@@ -1,0 +1,42 @@
+encryption_key: tlt_encode
+
+results_dir: /tao-pt/tao-experiments/result/nvdinov2
+
+# Backbone architecture must match the checkpoint being evaluated.
+model:
+  distill:
+    enable: False
+    disable_masking: False
+    pretrained_non_distill_pl_model_path: null
+  backbone:
+    teacher_type: "vit_l"
+    student_type: "vit_l"
+    drop_path_rate: 0.4
+    patch_size: 14
+    img_size: 518
+  head:
+    num_layers: 3
+    hidden_dim: 2048
+    bottleneck_dim: 384
+
+evaluate:
+  checkpoint: /tao-pt/tao-experiments/result/nvdinov2/train/teacher_epoch_002_step_00600.pth
+  results_dir: ${results_dir}/evaluate
+  num_gpus: 1
+  # Directory for cached feature tensors (extract-once). Point at scratch; null disables.
+  cache_dir: null
+  knn:
+    enabled: True
+    dataset_type: image_folder      # or webdataset
+    train_root: /tao-pt/tao-experiments/data/imagenet/train
+    val_root: /tao-pt/tao-experiments/data/imagenet/val
+    k: 20                           # protocol constant — keep 20 for paper comparability
+    crop: 224
+    batch_size: 128
+    num_workers: 8
+    # NV-DINOv2's adapter does not normalize, so the dataset applies ImageNet stats.
+    imagenet_normalize: True
+    num_classes: 1000
+    amp: True
+    # For a quick smoke test, cap the train index (remove for full ImageNet KNN):
+    max_train_samples: 50000

--- a/nvidia_tao_pytorch/ssl/nvdinov2/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/scripts/evaluate.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluate (embedding-quality) action for NV-DINOv2 SSL.
+
+Offline front-end onto the shared ``core/evaluation`` library: loads a trained
+checkpoint, wraps the teacher backbone in the ``(summary, features)`` model
+adapter, builds an :class:`EvalContext`, runs every enabled evaluator
+(currently KNN; segmentation + retrieval follow), and writes ``results.json``.
+
+The checkpoint format matches the sibling ``inference`` action — a ``.tlt`` /
+``.pth`` of the trained backbone weights (loaded via
+``restore_pretrained_weights``, which also mirrors student → teacher in the
+non-distillation case).
+"""
+
+import json
+import os
+
+import torch
+
+from nvidia_tao_pytorch.config.nvdinov2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.distributed.comm import (
+    get_local_rank,
+    is_dist_avail_and_initialized,
+)
+from nvidia_tao_pytorch.core.evaluation import (
+    EvalContext,
+    build_adapter,
+    build_enabled_evaluators,
+)
+from nvidia_tao_pytorch.core.evaluation.datasets.classification import (
+    build_classification_loader,
+)
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
+from nvidia_tao_pytorch.core.tlt_logging import logging, obfuscate_logs
+from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+
+
+def run_experiment(experiment_config, key):
+    """Run the embedding-quality evaluation suite and write ``results.json``."""
+    model_path, _ = initialize_evaluation_experiment(experiment_config, key)
+    results_dir = experiment_config.results_dir
+    eval_cfg = experiment_config.evaluate
+
+    device = torch.device(
+        f"cuda:{get_local_rank()}" if torch.cuda.is_available() else "cpu")
+
+    # Build the LightningModule and restore the trained backbone weights.
+    model = DinoV2PlModel(experiment_config)
+    if model_path and (model_path.endswith(".tlt") or model_path.endswith(".pth")):
+        model.pretrained_weights = model_path
+        model.restore_pretrained_weights()
+        logging.info("Loaded checkpoint: %s", model_path)
+    else:
+        raise NotImplementedError(
+            "evaluate.checkpoint must be a .tlt or .pth backbone weights file.")
+    model = model.to(device).eval()
+
+    # Keep NV-DINOv2's memory-efficient (xformers) attention — its non-custom
+    # attention path uses a different q/k/v layout and is NOT numerically
+    # equivalent, so disabling it collapses the features. The xformers path emits
+    # fp16; the evaluators run the backbone under bf16 autocast (the evaluate
+    # blocks default ``amp=True``), which reconciles the dtype for the fp32 linear
+    # layers. (Therefore keep ``evaluate.*.amp=True`` for NV-DINOv2.)
+
+    # Wrap the teacher backbone in the (summary, features) adapter.
+    adapter = build_adapter(
+        "nvdinov2", model,
+        patch_size=model.patch_size,
+        feature_dim=model.teacher_embed_dim,
+    ).to(device)
+
+    distributed = is_dist_avail_and_initialized()
+    ctx = EvalContext(
+        model=adapter,
+        network="nvdinov2",
+        device=device,
+        distributed=distributed,
+        build_loader=build_classification_loader,
+        cfg=eval_cfg,
+        results_dir=results_dir,
+        cache_dir=eval_cfg.cache_dir,
+    )
+
+    evaluators = build_enabled_evaluators(eval_cfg)
+    if not evaluators:
+        logging.warning("No evaluators enabled in the evaluate config — nothing to run.")
+
+    results = {}
+    for evaluator in evaluators:
+        logging.info("Running evaluator: %s", evaluator.name)
+        results.update(evaluator.run(ctx))
+
+    if get_local_rank() == 0:
+        os.makedirs(results_dir, exist_ok=True)
+        out_path = os.path.join(results_dir, "results.json")
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Wrote %s: %s", out_path, results)
+    return results
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# --config_path and --config_name are provided by the entrypoint script.
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="experiment_spec", schema=ExperimentConfig,
+)
+@monitor_status(name="NVDINOv2", mode="evaluate")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the NV-DINOv2 embedding-quality evaluation."""
+    obfuscate_logs(cfg)
+    run_experiment(experiment_config=cfg, key=cfg.encryption_key)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What changes are proposed in this pull request?

Front-ends onto the shared embedding-eval suite: nvdinov2 gains a new `evaluate` action (auto-registered subtask); MAE's `evaluate` gets additive dispatch — embedding suite when enabled, else the existing classification test. `EvalSuiteConfig` is mixed into each network's EvaluateConfig; README command table regenerated.

### Why are the changes needed?

Part 4/5 of the shared `core/evaluation` embedding-eval suite (epic TAO-2181): exposes the shared KNN/embedding evaluation to the NV-DINOv2 and MAE model families.

### Related issues

JIRA: TAO-2149 (parent epic TAO-2181). N/A for GitHub issues.

### Does this PR introduce _any_ user-facing change?

Yes — new `nvdinov2 evaluate` action; `mae evaluate` gains embedding-suite dispatch when enabled (existing behavior unchanged when disabled).

### How was this patch tested?

Verified in-container: `nvdinov2 evaluate` runs end-to-end. Config-compose unit tests for nvdinov2 + mae land in #80.

### Was this patch authored or co-authored using generative AI tooling?

Yes — portions were co-authored with an AI coding assistant.

### Release note

```release-note
Added an `evaluate` action for NV-DINOv2 and embedding-suite dispatch for MAE evaluate.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

Review the core-eval stack in order: #78 → #79 → #80 → #81 (this is part 4/5).

---
_Migrated from GitLab MR nvidia-tao-toolkit/tao-pytorch!617, rebased onto GitHub `main`._