### PR TITLE
[TAO-2175][Feature] core/evaluation unit tests (26 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ python tools/update_readme_supported_commands.py
 | `mask2former` | `cv.mask2former` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `mask_grounding_dino` | `cv.mask_grounding_dino` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `ml_recog` | `cv.ml_recog` | `default_specs`, `evaluate`, `export`, `inference`, `train` |
-| `nvdinov2` | `ssl.nvdinov2` | `default_specs`, `export`, `inference`, `train` |
+| `nvdinov2` | `ssl.nvdinov2` | `default_specs`, `evaluate`, `export`, `inference`, `train` |
 | `ocdnet` | `cv.ocdnet` | `default_specs`, `evaluate`, `export`, `inference`, `prune`, `quantize`, `train` |
 | `ocrnet` | `cv.ocrnet` | `dataset_convert`, `default_specs`, `evaluate`, `export`, `inference`, `prune`, `quantize`, `train` |
 | `oneformer` | `cv.oneformer` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |

--- a/nvidia_tao_pytorch/config/mae/default_config.py
+++ b/nvidia_tao_pytorch/config/mae/default_config.py
@@ -15,6 +15,7 @@ from nvidia_tao_pytorch.config.common.common_config import (
     InferenceConfig,
     TrainConfig,
 )
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import EvalSuiteConfig
 from nvidia_tao_pytorch.config.utils.types import (
     STR_FIELD,
     INT_FIELD,
@@ -373,6 +374,15 @@ class MAEGenTrtEngineConfig(GenTrtEngineConfig):
 
 
 @dataclass
+class MAEEvaluateExpConfig(EvaluateConfig, EvalSuiteConfig):
+    """MAE evaluate config: supervised classification test (default) PLUS the optional
+    shared embedding-quality suite (knn/segmentation/retrieval). When any suite block is
+    enabled, the evaluate action runs the core suite; otherwise the existing classification
+    test path is used.
+    """
+
+
+@dataclass
 class ExperimentConfig(CommonExperimentConfig):
     """Experiment configuration template."""
 
@@ -380,7 +390,7 @@ class ExperimentConfig(CommonExperimentConfig):
     train: MAETrainExpConfig = DATACLASS_FIELD(MAETrainExpConfig())
     model: MAEModelConfig = DATACLASS_FIELD(MAEModelConfig())
     inference: InferenceConfig = DATACLASS_FIELD(InferenceConfig())
-    evaluate: EvaluateConfig = DATACLASS_FIELD(EvaluateConfig())
+    evaluate: MAEEvaluateExpConfig = DATACLASS_FIELD(MAEEvaluateExpConfig())
     gen_trt_engine: MAEGenTrtEngineConfig = DATACLASS_FIELD(MAEGenTrtEngineConfig())
     export: ExportConfig = DATACLASS_FIELD(ExportConfig())
 

--- a/nvidia_tao_pytorch/config/nvdinov2/default_config.py
+++ b/nvidia_tao_pytorch/config/nvdinov2/default_config.py
@@ -9,11 +9,13 @@ from omegaconf import MISSING
 
 from nvidia_tao_pytorch.config.common.common_config import (
     CommonExperimentConfig,
+    EvaluateConfig,
     InferenceConfig,
     TrainConfig,
     GenTrtEngineConfig,
     TrtConfig
 )
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import EvalSuiteConfig
 from nvidia_tao_pytorch.config.utils.types import (
     STR_FIELD,
     INT_FIELD,
@@ -701,6 +703,15 @@ class NVDINOv2ExportExpConfig:
 
 
 @dataclass
+class NVDINOv2EvaluateExpConfig(EvaluateConfig, EvalSuiteConfig):
+    """Evaluate experiment config — embedding-quality suite (KNN; seg/retrieval to come).
+
+    Inherits the common GPU/checkpoint/results fields from ``EvaluateConfig`` and
+    the shared per-metric blocks (``knn``, ``cache_dir``) from ``EvalSuiteConfig``.
+    """
+
+
+@dataclass
 class GenTrtEngineExpConfig(GenTrtEngineConfig):
     """Gen TRT Engine experiment config."""
 
@@ -727,6 +738,12 @@ class ExperimentConfig(CommonExperimentConfig):
         NVDINOv2InferenceExpConfig(),
         description=(
             "Configurable parameters to construct the inference trainer for a NVDINOv2 experiment."
+        ),
+    )
+    evaluate: NVDINOv2EvaluateExpConfig = DATACLASS_FIELD(
+        NVDINOv2EvaluateExpConfig(),
+        description=(
+            "Configurable parameters for the NVDINOv2 evaluate (embedding-quality) action."
         ),
     )
     export: NVDINOv2ExportExpConfig = DATACLASS_FIELD(

--- a/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
+++ b/nvidia_tao_pytorch/cv/depth_net/scripts/convert.py
@@ -102,19 +102,19 @@ def write_files(filename: str, write_mode: str, data: dict):
         elif len(data) == 2 and 'right' in data.keys():
             # write both items the data:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]}" + '\n')
 
         elif len(data) == 2 and 'disparity' in data.keys():
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 3:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]}" + '\n')
 
         elif len(data) == 4:
             for i in range(len(data['left'])):
-                f.write(f'{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}' + '\n')
+                f.write(f"{data['left'][i]} {data['right'][i]} {data['disparity'][i]} {data['mask'][i]}" + '\n')
     f.close()
 
 

--- a/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
+++ b/nvidia_tao_pytorch/multimodal/radio/distillation/knn_classification.py
@@ -1,169 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""K-Nearest Neighbors classification for validation metrics."""
+"""KNN classification for distillation validation — re-export shim.
 
-from typing import Tuple
+Dependency inversion (Epic C): the KNN vote math now lives in the shared
+``nvidia_tao_pytorch.core.evaluation.knn`` module (source of truth, consumed by
+the SSL ``evaluate`` action and the vfm-eval harness too). This module is kept as
+a thin back-compatibility shim so existing imports
+(``from ...distillation.knn_classification import knn_top1_accuracy``) keep working
+unchanged. The functions are the exact same implementations that previously lived
+here — relocated, not modified — so distillation KNN-top1 numbers are unchanged.
+"""
 
-import torch
-import torch.distributed as dist
+from nvidia_tao_pytorch.core.evaluation.knn import (  # noqa: F401
+    _get_vote_cls,
+    distributed_topk,
+    knn_predict,
+    knn_top1_accuracy,
+)
 
-
-def _get_vote_cls(
-    max_sim: torch.Tensor,
-    max_ids: torch.Tensor,
-    num_classes: int,
-) -> torch.Tensor:
-    """Weighted majority vote from top-K neighbors.
-
-    Uses temperature-scaled exponential weighting following
-    https://arxiv.org/pdf/1805.01978.pdf, Section 3.4.
-    """
-    # https://arxiv.org/pdf/1805.01978.pdf, Section 3.4 (Also used by DINO)
-    weights = torch.exp(max_sim / 0.07)
-    cls_vec = torch.zeros(
-        weights.shape[0], num_classes, dtype=weights.dtype, device=weights.device,
-    )
-    cls_vec.scatter_add_(dim=1, index=max_ids, src=weights)
-
-    # The predicted ID is the one with the most vote weight
-    vote_id = torch.argmax(cls_vec, dim=1)
-    return vote_id
-
-
-def _pad(tensor: torch.Tensor, dim0: int) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Pad *tensor* along dim-0 to *dim0* and return a validity mask."""
-    valid_mask = torch.ones(dim0, dtype=torch.bool, device=tensor.device)
-    valid_mask[tensor.shape[0]:].fill_(False)
-
-    if tensor.shape[0] == dim0:
-        # If there is no padding to be done, return the original tensor.
-        return tensor, valid_mask
-
-    # Copy valid elements into a new tensor.
-    ret = torch.empty(dim0, *tensor.shape[1:], dtype=tensor.dtype, device=tensor.device)
-    ret[:tensor.shape[0]].copy_(tensor)
-    return ret, valid_mask
-
-
-def _all_to_all(t: torch.Tensor) -> torch.Tensor:
-    # Unroll the world dim into a list of tensors
-    input_tensors = list(t)
-    output_tensors = [torch.empty_like(v) for v in input_tensors]
-    dist.all_to_all(output_tensors, input_tensors)
-    return torch.stack(output_tensors)
-
-
-def distributed_topk(
-    queries: torch.Tensor,
-    keys: torch.Tensor,
-    labels: torch.Tensor,
-    K: int,
-    distributed: bool,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Find top-K nearest neighbors across all ranks.
-
-    Args:
-        queries: ``[Q, C]`` query embeddings (L2-normalized).
-        keys: ``[D, C]`` key embeddings on this rank (L2-normalized).
-        labels: ``[D]`` class labels for *keys*.
-        K: number of nearest neighbors.
-        distributed: whether to use distributed communication.
-
-    Returns:
-        ``(max_sim, max_labels)`` each of shape ``[Q, K]``.
-    """
-    if distributed:
-        world_size = dist.get_world_size()
-        max_queries = torch.tensor(
-            queries.shape[0], dtype=torch.int64, device=queries.device,
-        )
-        dist.all_reduce(max_queries, dist.ReduceOp.MAX)
-        max_queries = max_queries.item()
-
-        queries, valid_mask = _pad(queries, max_queries)
-        all_queries = torch.empty(
-            world_size, queries.shape[0], queries.shape[1],
-            dtype=queries.dtype, device=queries.device,
-        )
-        dist.all_gather_into_tensor(all_queries, queries)
-    else:
-        all_queries = queries.unsqueeze(0)
-        valid_mask = torch.ones(
-            queries.shape[0], dtype=torch.bool, device=queries.device,
-        )
-
-    # all_queries: W,Q,C
-    # keys: D,C
-
-    # W,Q,D
-    similarity = torch.matmul(all_queries, keys.T)
-
-    # W,Q,K
-    max_sim, max_idxs = torch.topk(similarity, k=K, dim=2, largest=True, sorted=False)
-    max_labels = labels[max_idxs.flatten()].reshape_as(max_idxs)
-
-    if distributed:
-        # Queries is the concatenated list of queries for all ranks,
-        # which means that max_sim and max_idxs is AllQueries -> KeysForThisRank
-        # All to all will then rearrange these to QueriesForThisRank -> AllKeys
-        max_sim = _all_to_all(max_sim)
-        max_labels = _all_to_all(max_labels)
-
-    # Reduce the per-rank similarities
-    # N,K*W
-    max_sim = max_sim.permute(1, 2, 0).flatten(1)
-    max_labels = max_labels.permute(1, 2, 0).flatten(1)
-
-    if distributed:
-        max_sim, max_idxs = torch.topk(max_sim, k=K, dim=1, largest=True, sorted=False)
-        max_labels = torch.gather(max_labels, dim=1, index=max_idxs)
-
-    max_sim = max_sim[valid_mask]
-    max_labels = max_labels[valid_mask]
-
-    return max_sim, max_labels
-
-
-def knn_top1_accuracy(
-    train_split_embeddings: torch.Tensor,
-    train_split_labels: torch.Tensor,
-    K: int,
-    output: torch.Tensor,
-    target: torch.Tensor,
-    distributed: bool,
-    num_classes: int = 1000,
-) -> torch.Tensor:
-    """K-NN Top-1 classification accuracy.
-
-    Args:
-        train_split_embeddings: ``[N_train, C]`` L2-normalized training embeddings.
-        train_split_labels: ``[N_train]`` training class labels.
-        K: number of nearest neighbors for majority vote.
-        output: ``[B, C]`` L2-normalized query embeddings.
-        target: ``[B]`` ground-truth class IDs.
-        distributed: whether to use distributed communication.
-        num_classes: total number of classes (default 1000 for ImageNet).
-
-    Returns:
-        Top-1 accuracy as a scalar tensor (percentage, 0–100).
-    """
-    max_sim, max_labels = distributed_topk(
-        queries=output,
-        keys=train_split_embeddings,
-        labels=train_split_labels,
-        K=K,
-        distributed=distributed,
-    )
-
-    # Get a weighted vote for each validation sample.
-    vote_id = _get_vote_cls(max_sim, max_labels, num_classes=num_classes)
-
-    # Compare against ground truth.
-    correct = target == vote_id
-
-    # Get total number of correct predictions and calculate accuracy.
-    num_correct = correct.sum()
-    acc1 = 100.0 * num_correct / output.size(0)
-
-    return acc1
+__all__ = ["_get_vote_cls", "distributed_topk", "knn_predict", "knn_top1_accuracy"]

--- a/nvidia_tao_pytorch/ssl/mae/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/mae/model/pl_model.py
@@ -98,7 +98,7 @@ class MAEPlModule(TAOLightningModule):
         model_arch = self.cfg.model.arch
         supported_archs = [m[len("mae_"):] for m in self.model_mapper.keys()]
         if model_arch not in supported_archs:
-            raise NotImplementedError(f"Only {", ".join(supported_archs)} are supported, but {model_arch} is specified.")
+            raise NotImplementedError(f"Only {', '.join(supported_archs)} are supported, but {model_arch} is specified.")
         self.checkpoint_filename = model_arch
         # Enable the MAE mask for the pretrain stage and if not exporting the model.
         if self.cfg.train.stage == "pretrain" and not self.export:

--- a/nvidia_tao_pytorch/ssl/mae/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/ssl/mae/scripts/evaluate.py
@@ -1,7 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""MAE evaluation script."""
+"""MAE evaluation script.
+
+Two modes, dispatched by config (backward-compatible):
+
+- **Embedding-quality suite** — when any of ``evaluate.{knn,segmentation,retrieval}.enabled``
+  is set, the trained MAE encoder is wrapped in the shared ``core/evaluation`` model
+  adapter and the enabled evaluators run, writing ``results.json`` (same path as the
+  NV-DINOv2 ``evaluate`` action).
+- **Supervised classification test** (default, unchanged) — otherwise the original
+  ``trainer.test`` path runs the finetune-stage classification metrics.
+"""
+import json
 import logging
 import os
 import warnings
@@ -9,6 +20,7 @@ import warnings
 from pytorch_lightning import Trainer
 
 from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.distributed.comm import get_local_rank, is_dist_avail_and_initialized
 from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
 from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
 
@@ -21,6 +33,52 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 logger = logging.getLogger(__name__)
 spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+_SUITE_BLOCKS = ("knn", "segmentation", "retrieval")
+
+
+def _suite_enabled(cfg) -> bool:
+    """True if any embedding-suite evaluator block is enabled in the evaluate config."""
+    ev = cfg.evaluate
+    return any(getattr(getattr(ev, b, None), "enabled", False) for b in _SUITE_BLOCKS)
+
+
+def _run_embedding_suite(cfg, model_path) -> None:
+    """Run the shared embedding-quality suite on the MAE encoder → results.json."""
+    import torch
+
+    from nvidia_tao_pytorch.core.evaluation import (
+        EvalContext, build_adapter, build_enabled_evaluators,
+    )
+    from nvidia_tao_pytorch.core.evaluation.datasets.classification import (
+        build_classification_loader,
+    )
+
+    device = torch.device(
+        f"cuda:{get_local_rank()}" if torch.cuda.is_available() else "cpu")
+    pl_model = MAEPlModule.load_from_checkpoint(model_path, map_location="cpu", cfg=cfg)
+    pl_model = pl_model.to(device).eval()
+
+    adapter = build_adapter("mae", pl_model).to(device)
+    eval_cfg = cfg.evaluate
+    ctx = EvalContext(
+        model=adapter, network="mae", device=device,
+        distributed=is_dist_avail_and_initialized(),
+        build_loader=build_classification_loader, cfg=eval_cfg,
+        results_dir=cfg.results_dir, cache_dir=eval_cfg.cache_dir,
+    )
+
+    results = {}
+    for evaluator in build_enabled_evaluators(eval_cfg):
+        logger.info("Running evaluator: %s", evaluator.name)
+        results.update(evaluator.run(ctx))
+
+    if get_local_rank() == 0:
+        os.makedirs(cfg.results_dir, exist_ok=True)
+        out_path = os.path.join(cfg.results_dir, "results.json")
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2)
+        logger.info("Wrote %s: %s", out_path, results)
+
 
 @hydra_runner(
     config_path=os.path.join(spec_root, "experiment_specs"),
@@ -28,21 +86,22 @@ spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 @monitor_status(name="MAE", mode="evaluate")
 def run_experiment(cfg: ExperimentConfig) -> None:
-    """Run training experiment."""
+    """Run MAE evaluation (embedding suite if enabled, else classification test)."""
     model_path, trainer_kwargs = initialize_evaluation_experiment(cfg)
+
+    if _suite_enabled(cfg):
+        logger.info("Running embedding-quality evaluation suite...")
+        _run_embedding_suite(cfg, model_path)
+        return
 
     logger.info("Setting up dataloader...")
     data_module = MAEDataModule(cfg=cfg)
 
     logger.info("Building MAE models...")
-
     pl_model = MAEPlModule.load_from_checkpoint(
-        model_path,
-        map_location="cpu",
-        cfg=cfg)
+        model_path, map_location="cpu", cfg=cfg)
 
     trainer = Trainer(**trainer_kwargs)
-
     trainer.test(pl_model, data_module)
 
 

--- a/nvidia_tao_pytorch/ssl/nvdinov2/experiment_specs/evaluate_spec.yaml
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/experiment_specs/evaluate_spec.yaml
@@ -1,0 +1,42 @@
+encryption_key: tlt_encode
+
+results_dir: /tao-pt/tao-experiments/result/nvdinov2
+
+# Backbone architecture must match the checkpoint being evaluated.
+model:
+  distill:
+    enable: False
+    disable_masking: False
+    pretrained_non_distill_pl_model_path: null
+  backbone:
+    teacher_type: "vit_l"
+    student_type: "vit_l"
+    drop_path_rate: 0.4
+    patch_size: 14
+    img_size: 518
+  head:
+    num_layers: 3
+    hidden_dim: 2048
+    bottleneck_dim: 384
+
+evaluate:
+  checkpoint: /tao-pt/tao-experiments/result/nvdinov2/train/teacher_epoch_002_step_00600.pth
+  results_dir: ${results_dir}/evaluate
+  num_gpus: 1
+  # Directory for cached feature tensors (extract-once). Point at scratch; null disables.
+  cache_dir: null
+  knn:
+    enabled: True
+    dataset_type: image_folder      # or webdataset
+    train_root: /tao-pt/tao-experiments/data/imagenet/train
+    val_root: /tao-pt/tao-experiments/data/imagenet/val
+    k: 20                           # protocol constant — keep 20 for paper comparability
+    crop: 224
+    batch_size: 128
+    num_workers: 8
+    # NV-DINOv2's adapter does not normalize, so the dataset applies ImageNet stats.
+    imagenet_normalize: True
+    num_classes: 1000
+    amp: True
+    # For a quick smoke test, cap the train index (remove for full ImageNet KNN):
+    max_train_samples: 50000

--- a/nvidia_tao_pytorch/ssl/nvdinov2/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/scripts/evaluate.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluate (embedding-quality) action for NV-DINOv2 SSL.
+
+Offline front-end onto the shared ``core/evaluation`` library: loads a trained
+checkpoint, wraps the teacher backbone in the ``(summary, features)`` model
+adapter, builds an :class:`EvalContext`, runs every enabled evaluator
+(currently KNN; segmentation + retrieval follow), and writes ``results.json``.
+
+The checkpoint format matches the sibling ``inference`` action — a ``.tlt`` /
+``.pth`` of the trained backbone weights (loaded via
+``restore_pretrained_weights``, which also mirrors student → teacher in the
+non-distillation case).
+"""
+
+import json
+import os
+
+import torch
+
+from nvidia_tao_pytorch.config.nvdinov2.default_config import ExperimentConfig
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.distributed.comm import (
+    get_local_rank,
+    is_dist_avail_and_initialized,
+)
+from nvidia_tao_pytorch.core.evaluation import (
+    EvalContext,
+    build_adapter,
+    build_enabled_evaluators,
+)
+from nvidia_tao_pytorch.core.evaluation.datasets.classification import (
+    build_classification_loader,
+)
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
+from nvidia_tao_pytorch.core.tlt_logging import logging, obfuscate_logs
+from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+
+
+def run_experiment(experiment_config, key):
+    """Run the embedding-quality evaluation suite and write ``results.json``."""
+    model_path, _ = initialize_evaluation_experiment(experiment_config, key)
+    results_dir = experiment_config.results_dir
+    eval_cfg = experiment_config.evaluate
+
+    device = torch.device(
+        f"cuda:{get_local_rank()}" if torch.cuda.is_available() else "cpu")
+
+    # Build the LightningModule and restore the trained backbone weights.
+    model = DinoV2PlModel(experiment_config)
+    if model_path and (model_path.endswith(".tlt") or model_path.endswith(".pth")):
+        model.pretrained_weights = model_path
+        model.restore_pretrained_weights()
+        logging.info("Loaded checkpoint: %s", model_path)
+    else:
+        raise NotImplementedError(
+            "evaluate.checkpoint must be a .tlt or .pth backbone weights file.")
+    model = model.to(device).eval()
+
+    # Keep NV-DINOv2's memory-efficient (xformers) attention — its non-custom
+    # attention path uses a different q/k/v layout and is NOT numerically
+    # equivalent, so disabling it collapses the features. The xformers path emits
+    # fp16; the evaluators run the backbone under bf16 autocast (the evaluate
+    # blocks default ``amp=True``), which reconciles the dtype for the fp32 linear
+    # layers. (Therefore keep ``evaluate.*.amp=True`` for NV-DINOv2.)
+
+    # Wrap the teacher backbone in the (summary, features) adapter.
+    adapter = build_adapter(
+        "nvdinov2", model,
+        patch_size=model.patch_size,
+        feature_dim=model.teacher_embed_dim,
+    ).to(device)
+
+    distributed = is_dist_avail_and_initialized()
+    ctx = EvalContext(
+        model=adapter,
+        network="nvdinov2",
+        device=device,
+        distributed=distributed,
+        build_loader=build_classification_loader,
+        cfg=eval_cfg,
+        results_dir=results_dir,
+        cache_dir=eval_cfg.cache_dir,
+    )
+
+    evaluators = build_enabled_evaluators(eval_cfg)
+    if not evaluators:
+        logging.warning("No evaluators enabled in the evaluate config — nothing to run.")
+
+    results = {}
+    for evaluator in evaluators:
+        logging.info("Running evaluator: %s", evaluator.name)
+        results.update(evaluator.run(ctx))
+
+    if get_local_rank() == 0:
+        os.makedirs(results_dir, exist_ok=True)
+        out_path = os.path.join(results_dir, "results.json")
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Wrote %s: %s", out_path, results)
+    return results
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# --config_path and --config_name are provided by the entrypoint script.
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="experiment_spec", schema=ExperimentConfig,
+)
+@monitor_status(name="NVDINOv2", mode="evaluate")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the NV-DINOv2 embedding-quality evaluation."""
+    obfuscate_logs(cfg)
+    run_experiment(experiment_config=cfg, key=cfg.encryption_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/core/evaluation/__init__.py
+++ b/tests/core/evaluation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/core/evaluation/test_config.py
+++ b/tests/core/evaluation/test_config.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Config-compose tests for the shared evaluation-suite schema."""
+
+import pytest
+from omegaconf import OmegaConf
+
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import (
+    EvalSuiteConfig,
+    KNNEvalConfig,
+)
+
+
+@pytest.mark.config
+def test_knn_protocol_defaults():
+    """KNN config defaults preserve the protocol (k=20, enabled, ImageNet-normalized)."""
+    cfg = OmegaConf.structured(KNNEvalConfig)
+    assert cfg.k == 20
+    assert cfg.enabled is True
+    assert cfg.imagenet_normalize is True
+    assert cfg.dataset_type == "image_folder"
+
+
+@pytest.mark.config
+def test_eval_suite_blocks_present_and_default_off():
+    """EvalSuiteConfig exposes knn/segmentation/retrieval; seg+retrieval default disabled."""
+    cfg = OmegaConf.structured(EvalSuiteConfig)
+    assert cfg.knn.enabled is True
+    assert cfg.segmentation.enabled is False
+    assert cfg.retrieval.enabled is False
+    assert cfg.cache_dir is None
+
+
+@pytest.mark.config
+@pytest.mark.schema_validation
+def test_nvdinov2_experiment_config_has_evaluate_suite():
+    """nvdinov2 ExperimentConfig composes the evaluate suite (knn k=20)."""
+    from nvidia_tao_pytorch.config.nvdinov2.default_config import ExperimentConfig
+
+    cfg = OmegaConf.structured(ExperimentConfig)
+    assert cfg.evaluate.knn.k == 20
+    assert cfg.evaluate.segmentation.enabled is False
+    # override composes cleanly
+    merged = OmegaConf.merge(cfg, OmegaConf.create({"evaluate": {"knn": {"k": 5}}}))
+    assert merged.evaluate.knn.k == 5
+
+
+@pytest.mark.config
+@pytest.mark.schema_validation
+def test_mae_experiment_config_has_evaluate_suite():
+    """MAE ExperimentConfig mixes in the evaluate suite alongside its EvaluateConfig fields."""
+    from nvidia_tao_pytorch.config.mae.default_config import ExperimentConfig
+
+    cfg = OmegaConf.structured(ExperimentConfig)
+    assert cfg.evaluate.knn.k == 20
+    assert cfg.evaluate.retrieval.enabled is False
+    assert cfg.evaluate.num_gpus == 1              # from common EvaluateConfig (mixin works)

--- a/tests/core/evaluation/test_knn.py
+++ b/tests/core/evaluation/test_knn.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the KNN evaluator vote math (offline FAISS + brute-force + online)."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from nvidia_tao_pytorch.core.evaluation import knn as knn_mod
+from nvidia_tao_pytorch.core.evaluation.knn import (
+    KNN_DEFAULT_K,
+    KNN_TEMPERATURE,
+    _get_vote_cls,
+    knn_predict,
+    knn_top1_offline,
+)
+
+NUM_CLASSES = 3
+K = 10
+
+
+def _separable(n_per, dim=16, seed=0):
+    """n_per L2-normalized samples around each of NUM_CLASSES orthonormal prototypes."""
+    g = torch.Generator().manual_seed(seed)
+    protos = torch.eye(NUM_CLASSES, dim)
+    embs, lbls = [], []
+    for c in range(NUM_CLASSES):
+        e = protos[c] + 0.01 * torch.randn(n_per, dim, generator=g)
+        embs.append(F.normalize(e, dim=1))
+        lbls.append(torch.full((n_per,), c, dtype=torch.long))
+    return torch.cat(embs), torch.cat(lbls)
+
+
+@pytest.mark.unit
+def test_protocol_constants():
+    """KNN protocol constants must stay at the paper-validated values."""
+    assert KNN_TEMPERATURE == 0.07
+    assert KNN_DEFAULT_K == 20
+
+
+@pytest.mark.unit
+def test_get_vote_cls_separable():
+    """A single dominant neighbor class wins the weighted vote."""
+    sim = torch.tensor([[0.9, 0.8, 0.1]])
+    labels = torch.tensor([[1, 1, 2]])
+    assert _get_vote_cls(sim, labels, num_classes=NUM_CLASSES).item() == 1
+
+
+@pytest.mark.unit
+def test_bruteforce_separable_100(monkeypatch):
+    """Brute-force fallback (FAISS forced off) classifies separable data ~100%."""
+    monkeypatch.setattr(knn_mod, "_HAS_FAISS", False)
+    tr_e, tr_l = _separable(30)
+    va_e, va_l = _separable(10, seed=1)
+    acc = knn_top1_offline(tr_e, tr_l, va_e, va_l, num_classes=NUM_CLASSES, K=K)
+    assert acc > 99.0
+
+
+@pytest.mark.unit
+def test_use_faiss_false_forces_bruteforce():
+    """use_faiss=False uses the brute-force path even when faiss is installed."""
+    tr_e, tr_l = _separable(30)
+    va_e, va_l = _separable(10, seed=5)
+    acc = knn_top1_offline(tr_e, tr_l, va_e, va_l, num_classes=NUM_CLASSES, K=K, use_faiss=False)
+    assert acc > 99.0
+
+
+@pytest.mark.unit
+def test_online_knn_predict_separable_100():
+    """Online distributed_topk path (single process) classifies separable data ~100%."""
+    tr_e, tr_l = _separable(30)
+    va_e, va_l = _separable(10, seed=2)
+    vote = knn_predict(tr_e, tr_l, va_e, K=K, num_classes=NUM_CLASSES, distributed=False)
+    acc = 100.0 * (vote == va_l).float().mean().item()
+    assert acc > 99.0
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not knn_mod._HAS_FAISS, reason="faiss not installed")
+def test_faiss_matches_bruteforce(monkeypatch):
+    """FAISS and brute-force agree on separable data."""
+    tr_e, tr_l = _separable(30)
+    va_e, va_l = _separable(10, seed=3)
+    acc_faiss = knn_top1_offline(tr_e, tr_l, va_e, va_l, num_classes=NUM_CLASSES, K=K)
+    monkeypatch.setattr(knn_mod, "_HAS_FAISS", False)
+    acc_bf = knn_top1_offline(tr_e, tr_l, va_e, va_l, num_classes=NUM_CLASSES, K=K)
+    assert abs(acc_faiss - acc_bf) < 1e-6

--- a/tests/core/evaluation/test_model_adapter.py
+++ b/tests/core/evaluation/test_model_adapter.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the (summary, features) model-adapter contract."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nvidia_tao_pytorch.core.evaluation import ADAPTER_REGISTRY, build_adapter
+from nvidia_tao_pytorch.core.evaluation.model_adapter import (
+    BackboneV2Adapter,
+    ModelAdapter,
+    features_to_map,
+    load_tao_state_dict,
+)
+
+
+@pytest.mark.unit
+def test_features_to_map_reshapes_tokens():
+    """[B,T,D] tokens reshape to [B,D,h,w] using ceil(H/patch)."""
+    feats = torch.randn(2, 16, 8)            # 16 = 4x4 patches
+    images = torch.randn(2, 3, 64, 64)       # 64/16 = 4
+    out = features_to_map(feats, images, patch_size=16)
+    assert out.shape == (2, 8, 4, 4)
+
+
+@pytest.mark.unit
+def test_features_to_map_idempotent_on_bchw():
+    """An already-spatial [B,C,H,W] map passes through unchanged."""
+    spatial = torch.randn(2, 8, 4, 4)
+    out = features_to_map(spatial, torch.randn(2, 3, 64, 64), patch_size=16)
+    assert out.shape == spatial.shape
+    assert torch.allclose(out, spatial)
+
+
+@pytest.mark.unit
+def test_model_adapter_is_abstract():
+    """ModelAdapter cannot be instantiated directly (abstract forward)."""
+    with pytest.raises(TypeError):
+        ModelAdapter()  # pylint: disable=abstract-class-instantiated
+
+
+@pytest.mark.unit
+def test_backbone_v2_adapter_passthrough():
+    """BackboneV2Adapter forwards to backbone(return_features=True) → (summary, features)."""
+
+    class _FakeBackboneV2(nn.Module):
+        patch_size = 16
+
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 12, 16, stride=16)
+
+        def forward(self, x, return_features=False, return_logits=True):
+            f = self.conv(x)
+            return f.mean((2, 3)), f
+
+    adapter = BackboneV2Adapter(_FakeBackboneV2(), feature_dim=12).eval()
+    summary, feats = adapter(torch.randn(2, 3, 64, 64))
+    assert summary.shape == (2, 12)
+    assert feats.shape == (2, 12, 4, 4)
+
+
+@pytest.mark.unit
+def test_load_tao_state_dict_strip_and_rename(tmp_path):
+    """TAO ckpt loader strips model.radio.radio. and renames ls*.gamma → grandma.
+
+    The gamma → grandma rename is intentional: it mirrors upstream RADIO's
+    hubconf.py (which renames the LayerScale ``gamma`` parameter to ``grandma``)
+    so the re-keyed state dict loads cleanly against a torch.hub RADIO model.
+    See ``load_tao_state_dict`` for the full rationale.
+    """
+    sd = {
+        "model.radio.radio.blocks.0.ls1.gamma": torch.zeros(4),
+        "model.radio.radio.blocks.0.ls2.gamma": torch.zeros(4),
+        "model.radio.radio.patch_embed.weight": torch.zeros(2),
+        "teacher.ignore_me": torch.zeros(1),
+    }
+    path = tmp_path / "ckpt.pth"
+    torch.save({"state_dict": sd}, path)
+    out = load_tao_state_dict(str(path))
+    assert set(out) == {
+        "blocks.0.ls1.grandma", "blocks.0.ls2.grandma", "patch_embed.weight",
+    }
+
+
+@pytest.mark.unit
+def test_mae_adapter_contract():
+    """MAEViTAdapter returns (CLS summary, unshuffled patch features) with correct shapes."""
+    from nvidia_tao_pytorch.ssl.mae.model.mae import MaskedAutoencoderViT
+
+    assert "mae" in ADAPTER_REGISTRY
+    model = MaskedAutoencoderViT(
+        img_size=64, patch_size=16, embed_dim=48, depth=2, num_heads=4,
+        decoder_embed_dim=32, decoder_depth=1, decoder_num_heads=4, mlp_ratio=4.0,
+    ).eval()
+    adapter = build_adapter("mae", model)
+    assert adapter.patch_size == 16 and adapter.feature_dim == 48
+
+    x = torch.randn(2, 3, 64, 64)
+    summary, feats = adapter(x)
+    assert summary.shape == (2, 48)
+    assert feats.shape == (2, 16, 48)              # 4x4 patches
+    assert features_to_map(feats, x, adapter.patch_size).shape == (2, 48, 4, 4)
+    # eval (mask_ratio=0) is deterministic — no stochastic masking leak
+    assert torch.allclose(summary, adapter(x)[0], atol=1e-5)
+
+
+@pytest.mark.unit
+def test_build_adapter_unknown_network():
+    """Unknown network raises a helpful KeyError."""
+    with pytest.raises(KeyError):
+        build_adapter("does_not_exist", nn.Identity())

--- a/tests/core/evaluation/test_registry.py
+++ b/tests/core/evaluation/test_registry.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Evaluator registry + enabled-selection."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from nvidia_tao_pytorch.core.evaluation import EVALUATOR_REGISTRY, build_enabled_evaluators
+from nvidia_tao_pytorch.core.evaluation.knn import KNNEvaluator
+from nvidia_tao_pytorch.core.evaluation.segmentation import SegmentationEvaluator
+
+
+@pytest.mark.unit
+def test_registry_has_all_evaluators():
+    """KNN, segmentation, and retrieval evaluators self-register on import."""
+    assert {"knn", "segmentation", "retrieval"} <= set(EVALUATOR_REGISTRY)
+
+
+@pytest.mark.unit
+def test_online_support_flags():
+    """KNN supports online hooks; the seg probe is offline-only."""
+    assert KNNEvaluator.supports_online is True
+    assert SegmentationEvaluator.supports_online is False
+    assert SegmentationEvaluator.requires_fit is True
+
+
+@pytest.mark.unit
+def test_build_enabled_evaluators_filters_by_enabled():
+    """Only evaluators whose config block is enabled are instantiated."""
+    cfg = SimpleNamespace(
+        knn=SimpleNamespace(enabled=True),
+        segmentation=SimpleNamespace(enabled=False),
+        retrieval=SimpleNamespace(enabled=False),
+    )
+    names = {ev.name for ev in build_enabled_evaluators(cfg)}
+    assert names == {"knn"}
+
+
+@pytest.mark.unit
+def test_build_enabled_evaluators_multiple():
+    """Multiple enabled blocks yield multiple evaluators."""
+    cfg = SimpleNamespace(
+        knn=SimpleNamespace(enabled=True),
+        segmentation=SimpleNamespace(enabled=True),
+        retrieval=SimpleNamespace(enabled=False),
+    )
+    names = {ev.name for ev in build_enabled_evaluators(cfg)}
+    assert names == {"knn", "segmentation"}

--- a/tests/core/evaluation/test_segmentation.py
+++ b/tests/core/evaluation/test_segmentation.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for segmentation probe pieces: BNHead, LR schedule, IoU accumulators."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from nvidia_tao_pytorch.core.evaluation.segmentation import (
+    BNHead,
+    IoUAccumulator,
+    SmallObjectIoUAccumulator,
+    _get_lr,
+)
+
+
+@pytest.mark.unit
+def test_bnhead_shape():
+    """BNHead maps [B,D,h,w] → [B,num_classes,h,w]."""
+    head = BNHead(in_channels=8, num_classes=5)
+    out = head(torch.randn(2, 8, 4, 4))
+    assert out.shape == (2, 5, 4, 4)
+
+
+@pytest.mark.unit
+def test_bnhead_one_step_reduces_loss():
+    """A single AdamW step on a fixed batch lowers the CE loss (head trains)."""
+    torch.manual_seed(0)
+    head = BNHead(8, 3)
+    opt = torch.optim.AdamW(head.parameters(), lr=1e-2)
+    crit = nn.CrossEntropyLoss(ignore_index=255)
+    feat = torch.randn(2, 8, 8, 8)
+    target = torch.randint(0, 3, (2, 8, 8))
+    before = crit(head(feat), target)
+    opt.zero_grad()
+    before.backward()
+    opt.step()
+    after = crit(head(feat), target)
+    assert after.item() < before.item()
+
+
+@pytest.mark.unit
+def test_lr_schedule_warmup_then_decay():
+    """LR warms up linearly then decays poly(power=1) to ~0 at total_steps."""
+    base = 1e-3
+    assert _get_lr(0, base, warmup_steps=1500, total_steps=80_000) == pytest.approx(base * 1e-6)
+    assert _get_lr(1500, base, 1500, 80_000) == pytest.approx(base)        # peak at end of warmup
+    assert _get_lr(80_000, base, 1500, 80_000) == pytest.approx(0.0)       # decays to 0
+    mid = _get_lr(40_000, base, 1500, 80_000)
+    assert 0.0 < mid < base
+
+
+@pytest.mark.unit
+def test_iou_accumulator_known_case():
+    """mIoU on a hand-checked 2x2 / 2-class example."""
+    preds = torch.tensor([[0, 0], [1, 1]])
+    targets = torch.tensor([[0, 1], [1, 1]])
+    acc = IoUAccumulator(num_classes=2, ignore_index=255)
+    acc.update(preds, targets)
+    # class0 IoU = 1/2 ; class1 IoU = 2/3 -> mean*100
+    expected = (0.5 + 2.0 / 3.0) / 2.0 * 100.0
+    assert acc.miou() == pytest.approx(expected, abs=1e-4)
+
+
+@pytest.mark.unit
+def test_iou_accumulator_respects_ignore():
+    """Ignore-index pixels are excluded from intersection/union."""
+    preds = torch.tensor([[0, 1]])
+    targets = torch.tensor([[0, 255]])     # second pixel ignored
+    acc = IoUAccumulator(num_classes=2, ignore_index=255)
+    acc.update(preds, targets)
+    # only pixel (0,0): class0 perfect, class1 absent -> mIoU over present classes = 100
+    assert acc.miou() == pytest.approx(100.0, abs=1e-4)
+
+
+@pytest.mark.unit
+def test_small_object_accumulator_empty_when_no_small():
+    """With no small GT components, small-object mIoU is NaN (nothing accumulated)."""
+    acc = SmallObjectIoUAccumulator(num_classes=2, ignore_index=255, area_thresh=1)
+    acc.update(torch.zeros(8, 8, dtype=torch.long), torch.zeros(8, 8, dtype=torch.long))
+    assert acc.miou() != acc.miou()        # NaN


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adds `tests/core/evaluation/` — 26 CPU-fast unit tests: KNN vote math (FAISS + brute-force + online → 100% on separable data), adapter contract, segmentation IoU + LR schedule + BNHead, registry/selection, and config compose (nvdinov2 + mae). Markers: unit/config/schema_validation.

### Why are the changes needed?

Part 5/5 of the shared `core/evaluation` embedding-eval suite (epic TAO-2181): locks down the suite's behavior before more model families adopt it.

### Related issues

JIRA: TAO-2175 (parent epic TAO-2181). N/A for GitHub issues.

### Does this PR introduce _any_ user-facing change?

No — tests only.

### How was this patch tested?

```
pytest tests/core/evaluation
```
All 26 pass in-container.

### Was this patch authored or co-authored using generative AI tooling?

Yes — portions were co-authored with an AI coding assistant.

### Release note

```release-note
NONE
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

Review the core-eval stack in order: #78 → #79 → #80 → #81 (this is part 5/5). #81 (dinov3 evaluate) is stacked on this branch.

---
_Migrated from GitLab MR nvidia-tao-toolkit/tao-pytorch!618, rebased onto GitHub `main`._