### PR TITLE
[TAO-2382][Feature] Add dinov3 evaluate action (shared core/evaluation suite)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ python tools/update_readme_supported_commands.py
 | `deformable_detr` | `cv.deformable_detr` | `convert`, `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `depth_net` | `cv.depth_net` | `convert`, `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `dino` | `cv.dino` | `convert`, `default_specs`, `distill`, `evaluate`, `export`, `inference`, `quantize`, `train` |
-| `dinov3` | `ssl.dinov3` | `convert`, `default_specs`, `export`, `inference`, `train` |
+| `dinov3` | `ssl.dinov3` | `convert`, `default_specs`, `evaluate`, `export`, `inference`, `train` |
 | `grounding_dino` | `cv.grounding_dino` | `default_specs`, `evaluate`, `export`, `inference`, `quantize`, `train` |
 | `mae` | `ssl.mae` | `default_specs`, `evaluate`, `export`, `inference`, `train` |
 | `mal` | `cv.mal` | `default_specs`, `evaluate`, `inference`, `train` |

--- a/nvidia_tao_pytorch/config/dinov3/default_config.py
+++ b/nvidia_tao_pytorch/config/dinov3/default_config.py
@@ -43,7 +43,9 @@ from nvidia_tao_pytorch.config.nvdinov2.default_config import (
 from nvidia_tao_pytorch.config.common.common_config import (
     CommonExperimentConfig,
     CuDNNConfig,
+    EvaluateConfig,
 )
+from nvidia_tao_pytorch.config.ssl_evaluation.default_config import EvalSuiteConfig
 
 # DINOv3 patch-16 ViT architectures supported by the backbone config.
 SUPPORTED_BACKBONES = [
@@ -541,6 +543,16 @@ class DINOv3ConvertConfig:
 
 
 @dataclass
+class DINOv3EvaluateExpConfig(EvaluateConfig, EvalSuiteConfig):
+    """Evaluate experiment config — embedding-quality suite (KNN; seg/retrieval to come).
+
+    Mirrors ``NVDINOv2EvaluateExpConfig``: inherits the common GPU/checkpoint/results
+    fields from ``EvaluateConfig`` and the shared per-metric blocks (``knn``,
+    ``cache_dir``) from ``EvalSuiteConfig``.
+    """
+
+
+@dataclass
 class ExperimentConfig(CommonExperimentConfig):
     """DINOv3 experiment config."""
 
@@ -559,6 +571,10 @@ class ExperimentConfig(CommonExperimentConfig):
     inference: NVDINOv2InferenceExpConfig = DATACLASS_FIELD(
         NVDINOv2InferenceExpConfig(),
         description="Configurable parameters to construct the inference trainer for a DINOv3 experiment.",
+    )
+    evaluate: DINOv3EvaluateExpConfig = DATACLASS_FIELD(
+        DINOv3EvaluateExpConfig(),
+        description="Configurable parameters for the DINOv3 evaluate (embedding-quality) action.",
     )
     export: DINOv3ExportExpConfig = DATACLASS_FIELD(
         DINOv3ExportExpConfig(),

--- a/nvidia_tao_pytorch/core/evaluation/datasets/classification.py
+++ b/nvidia_tao_pytorch/core/evaluation/datasets/classification.py
@@ -29,6 +29,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from PIL import ImageFile
 import torch
 from torch.utils.data import DataLoader, DistributedSampler, Subset
 import torchvision.transforms as T
@@ -37,6 +38,11 @@ from nvidia_tao_pytorch.core.distributed.comm import get_global_rank, get_world_
 from nvidia_tao_pytorch.cv.ml_recog.dataloader.datasets.image_datasets import (
     MetricLearnImageFolder,
 )
+
+# Tolerate truncated JPEGs (ImageNet train has a few) instead of crashing a
+# multi-hour extraction — same policy as c-radiov4 eval_cls.py and the mae /
+# classification_pyt / radio dataloaders.
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 logger = logging.getLogger(__name__)
 

--- a/nvidia_tao_pytorch/core/evaluation/knn.py
+++ b/nvidia_tao_pytorch/core/evaluation/knn.py
@@ -377,7 +377,7 @@ class KNNEvaluator(Evaluator):
         def _extract(loader_info, split, suffix=""):
             path = None
             if ctx.cache_dir:
-                tag = getattr(cfg, "cache_tag", ctx.network)
+                tag = getattr(cfg, "cache_tag", None) or ctx.network
                 res = getattr(cfg, "crop", 224)
                 path = embedding_cache_path(ctx.cache_dir, tag, res, split, suffix)
             return cached_embeddings(

--- a/nvidia_tao_pytorch/core/evaluation/model_adapter.py
+++ b/nvidia_tao_pytorch/core/evaluation/model_adapter.py
@@ -246,6 +246,8 @@ class MAEViTAdapter(ModelAdapter):
 # BackboneV2Adapter(model.backbone) — it's a passthrough to backbone_v2's contract.
 ADAPTER_REGISTRY: Dict[str, Type[ModelAdapter]] = {
     "nvdinov2": DinoV2Adapter,            # bespoke: DINOv2 ViT returns a token dict, not backbone_v2
+    "dinov3": DinoV2Adapter,              # DinoV3PlModel(DinoV2PlModel): teacher.backbone returns the
+    #   same x_norm_clstoken/x_norm_patchtokens dict; embed_dim/patch_size come in via cfg.
     "mae": MAEViTAdapter,                 # ViT-MAE encoder (forward_encoder); FCMAE/Hiera TODO (open item #1)
     # RADIO / ViT / FasterViT students: BackboneV2Adapter (backbone_v2 native contract);
     #   only the torch.hub upstream RADIO path needs c-radiov4's bespoke adapter.

--- a/nvidia_tao_pytorch/ssl/dinov3/experiment_specs/evaluate_spec.yaml
+++ b/nvidia_tao_pytorch/ssl/dinov3/experiment_specs/evaluate_spec.yaml
@@ -1,0 +1,44 @@
+encryption_key: tlt_encode
+
+results_dir: /tao-pt/tao-experiments/result/dinov3
+
+# Backbone architecture must match the checkpoint being evaluated.
+model:
+  distill:
+    enable: False
+    disable_masking: False
+    pretrained_non_distill_pl_model_path: null
+  backbone:
+    teacher_type: "vit_b"
+    student_type: "vit_b"
+    patch_size: 16
+    img_size: 256
+  head:
+    num_layers: 3
+    hidden_dim: 2048
+    bottleneck_dim: 384
+
+evaluate:
+  # A stripped backbone file (student_*.pth / teacher_*.pth from train) or
+  # timm-format DINOv3 weights (.pth / .safetensors).
+  checkpoint: /tao-pt/tao-experiments/result/dinov3/train/teacher_epoch_002_step_00600.pth
+  results_dir: ${results_dir}/evaluate
+  num_gpus: 1
+  # Directory for cached feature tensors (extract-once). Point at scratch; null disables.
+  cache_dir: null
+  knn:
+    enabled: True
+    dataset_type: image_folder      # or webdataset
+    train_root: /tao-pt/tao-experiments/data/imagenet/train
+    val_root: /tao-pt/tao-experiments/data/imagenet/val
+    k: 20                           # protocol constant — keep 20 for paper comparability
+    crop: 224
+    batch_size: 128
+    num_workers: 8
+    # DINOv3 expects ImageNet-normalized inputs (matches the SSL train/inference
+    # pipeline); the adapter does not normalize, so the dataset applies the stats.
+    imagenet_normalize: True
+    num_classes: 1000
+    amp: True
+    # For a quick smoke test, cap the train index (remove for full ImageNet KNN):
+    max_train_samples: 50000

--- a/nvidia_tao_pytorch/ssl/dinov3/scripts/evaluate.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/scripts/evaluate.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluate (embedding-quality) action for DINOv3 SSL.
+
+Offline front-end onto the shared ``core/evaluation`` library, mirroring the
+``nvdinov2`` evaluate action: loads a trained checkpoint, wraps the teacher
+backbone in the ``(summary, features)`` model adapter, builds an
+:class:`EvalContext`, runs every enabled evaluator (currently KNN;
+segmentation + retrieval follow), and writes ``results.json``.
+
+The checkpoint follows the sibling ``inference`` / ``convert`` conventions —
+either a stripped backbone file (``student_*.pth`` / ``teacher_*.pth``) or
+timm-format DINOv3 weights (``.pth`` / ``.safetensors``), loaded via
+``restore_pretrained_weights`` (which remaps timm keys and mirrors
+student → teacher in the non-distillation case).
+"""
+
+import json
+import os
+
+import torch
+
+from nvidia_tao_pytorch.config.dinov3.default_config import ExperimentConfig
+from nvidia_tao_pytorch.core.decorators.workflow import monitor_status
+from nvidia_tao_pytorch.core.distributed.comm import (
+    get_local_rank,
+    is_dist_avail_and_initialized,
+)
+from nvidia_tao_pytorch.core.evaluation import (
+    EvalContext,
+    build_adapter,
+    build_enabled_evaluators,
+)
+from nvidia_tao_pytorch.core.evaluation.datasets.classification import (
+    build_classification_loader,
+)
+from nvidia_tao_pytorch.core.hydra.hydra_runner import hydra_runner
+from nvidia_tao_pytorch.core.initialize_experiments import initialize_evaluation_experiment
+from nvidia_tao_pytorch.core.tlt_logging import logging, obfuscate_logs
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+
+
+def run_experiment(experiment_config, key):
+    """Run the embedding-quality evaluation suite and write ``results.json``."""
+    model_path, _ = initialize_evaluation_experiment(experiment_config, key)
+    results_dir = experiment_config.results_dir
+    eval_cfg = experiment_config.evaluate
+
+    device = torch.device(
+        f"cuda:{get_local_rank()}" if torch.cuda.is_available() else "cpu")
+
+    # Build the LightningModule and restore the trained backbone weights.
+    model = DinoV3PlModel(experiment_config)
+    if model_path and model_path.endswith((".tlt", ".pth", ".safetensors")):
+        model.pretrained_weights = model_path
+        model.restore_pretrained_weights()
+        logging.info("Loaded checkpoint: %s", model_path)
+    else:
+        raise NotImplementedError(
+            "evaluate.checkpoint must be a .tlt/.pth/.safetensors backbone weights file.")
+    model = model.to(device).eval()
+
+    # Keep DINOv3's memory-efficient (xformers) attention as built. Its RoPE
+    # attention path emits fp16 (q/k/v are hard-cast to half); the evaluators
+    # run the backbone under bf16 autocast (the evaluate blocks default
+    # ``amp=True``), which reconciles the dtype for the fp32 linear layers —
+    # the same arrangement the nvdinov2 evaluate action uses. (Therefore keep
+    # ``evaluate.*.amp=True`` for DINOv3.)
+
+    # Wrap the teacher backbone in the (summary, features) adapter.
+    adapter = build_adapter(
+        "dinov3", model,
+        patch_size=model.patch_size,
+        feature_dim=model.teacher_embed_dim,
+    ).to(device)
+
+    distributed = is_dist_avail_and_initialized()
+    ctx = EvalContext(
+        model=adapter,
+        network="dinov3",
+        device=device,
+        distributed=distributed,
+        build_loader=build_classification_loader,
+        cfg=eval_cfg,
+        results_dir=results_dir,
+        cache_dir=eval_cfg.cache_dir,
+    )
+
+    evaluators = build_enabled_evaluators(eval_cfg)
+    if not evaluators:
+        logging.warning("No evaluators enabled in the evaluate config — nothing to run.")
+
+    results = {}
+    for evaluator in evaluators:
+        logging.info("Running evaluator: %s", evaluator.name)
+        results.update(evaluator.run(ctx))
+
+    if get_local_rank() == 0:
+        os.makedirs(results_dir, exist_ok=True)
+        out_path = os.path.join(results_dir, "results.json")
+        with open(out_path, "w") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Wrote %s: %s", out_path, results)
+    return results
+
+
+spec_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+# --config_path and --config_name are provided by the entrypoint script.
+@hydra_runner(
+    config_path=os.path.join(spec_root, "experiment_specs"),
+    config_name="experiment_spec", schema=ExperimentConfig,
+)
+@monitor_status(name="DINOv3", mode="evaluate")
+def main(cfg: ExperimentConfig) -> None:
+    """Run the DINOv3 embedding-quality evaluation."""
+    obfuscate_logs(cfg)
+    run_experiment(experiment_config=cfg, key=cfg.encryption_key)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/core/evaluation/test_model_adapter.py
+++ b/tests/core/evaluation/test_model_adapter.py
@@ -108,6 +108,33 @@ def test_mae_adapter_contract():
 
 
 @pytest.mark.unit
+def test_dinov3_adapter_contract():
+    """The dinov3 registry entry reuses DinoV2Adapter (same teacher-backbone token dict)."""
+    from nvidia_tao_pytorch.core.evaluation.model_adapter import DinoV2Adapter
+
+    assert ADAPTER_REGISTRY["dinov3"] is DinoV2Adapter
+
+    class _FakeBackbone(nn.Module):
+        def forward(self, x):
+            b = x.shape[0]
+            return {
+                "x_norm_clstoken": torch.randn(b, 48),
+                "x_norm_patchtokens": torch.randn(b, 16, 48),
+            }
+
+    pl_model = nn.Module()
+    pl_model.teacher = nn.ModuleDict({"backbone": _FakeBackbone()})
+    adapter = build_adapter("dinov3", pl_model, patch_size=16, feature_dim=48)
+    assert adapter.patch_size == 16 and adapter.feature_dim == 48
+
+    x = torch.randn(2, 3, 64, 64)
+    summary, feats = adapter(x)
+    assert summary.shape == (2, 48)
+    assert feats.shape == (2, 16, 48)
+    assert features_to_map(feats, x, adapter.patch_size).shape == (2, 48, 4, 4)
+
+
+@pytest.mark.unit
 def test_build_adapter_unknown_network():
     """Unknown network raises a helpful KeyError."""
     with pytest.raises(KeyError):

--- a/tests/ssl_unit_test/dinov3/test_config.py
+++ b/tests/ssl_unit_test/dinov3/test_config.py
@@ -113,6 +113,21 @@ def test_dinov3_256_transform_defaults():
 
 @pytest.mark.config
 @pytest.mark.ssl_unit
+def test_evaluate_block_defaults():
+    """The evaluate block carries the shared eval-suite metrics (KNN on by default)."""
+    cfg = OmegaConf.structured(ExperimentConfig())
+    ev = cfg.evaluate
+    assert ev.knn.enabled is True
+    assert ev.knn.k == 20
+    # DINOv3 matches the SSL train/inference pipeline: ImageNet-normalized inputs.
+    assert ev.knn.imagenet_normalize is True
+    assert ev.segmentation.enabled is False
+    assert ev.retrieval.enabled is False
+    assert ev.cache_dir is None
+
+
+@pytest.mark.config
+@pytest.mark.ssl_unit
 def test_param_map_vit_b():
     """The v3 param map carries the ViT-B (768/12/12, standard MLP) entry."""
     assert map_params["embed_dim"]["vit_b"] == 768


### PR DESCRIPTION
### What changes are proposed in this pull request?

Mirrors the nvdinov2 evaluate action for the DINOv3 SSL family (Epic G), plus two small core/evaluation robustness fixes found during validation:

- **TAO-2382** — `dinov3 evaluate`: registers `dinov3` in `ADAPTER_REGISTRY` (reuses `DinoV2Adapter`; `DinoV3PlModel(DinoV2PlModel)` exposes the same `teacher.backbone` token dict); adds `ssl/dinov3/scripts/evaluate.py` (checkpoint via `restore_pretrained_weights`, accepts stripped teacher/student `.pth` or timm-format `.pth`/`.safetensors`); `DINOv3EvaluateExpConfig(EvaluateConfig, EvalSuiteConfig)` + `evaluate_spec.yaml` (KNN-only, ImageNet normalization); README table regen.
- **TAO-2386** — fixes `cache_tag` fallback when the config field is present but `None` (crashed any run with `evaluate.cache_dir` set).
- **TAO-2383** — tolerates truncated JPEGs in the eval classification dataset (`ImageFile.LOAD_TRUNCATED_IMAGES = True`, same policy as the mae/classification_pyt/radio dataloaders).

### Why are the changes needed?

Completes embedding-quality evaluation coverage for the DINOv3 family through the shared `core/evaluation` suite, and fixes two crashes hit during full-scale validation (a `cache_tag` crash with `cache_dir` set, and a truncated ImageNet JPEG killing full-split extraction).

### Related issues

JIRA: TAO-2381 / TAO-2382 / TAO-2383 / TAO-2386. N/A for GitHub issues.

### Does this PR introduce _any_ user-facing change?

Yes — new `dinov3 evaluate` action. Also: runs with `evaluate.cache_dir` set no longer crash, and truncated JPEGs no longer abort evaluation dataset extraction.

### How was this patch tested?

Validation on a4u8g-0146 (single A100):

| Check | Result |
|---|---|
| Unit tests (`tests/core/evaluation` + dinov3 config) | 39 passed |
| timm feature-parity (published ViT-B/16, 256 + 768 px) | pass, 162/162 tensors remapped |
| `dinov3 evaluate` ImageNet KNN, full 1.28M index @224 | **knn_top1 = 82.99%** (published DINOv3 ViT-B/16 k-NN ballpark) |
| C-RADIOv4-H parity through the same core KNN path @512 | **86.42% vs paper 86.59** (Δ −0.17) |

pylint 10.00/10 on touched files.

### Was this patch authored or co-authored using generative AI tooling?

Yes — portions were co-authored with an AI coding assistant.

### Release note

```release-note
Added a dinov3 evaluate action for embedding-quality (KNN) evaluation of DINOv3 checkpoints.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [x] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

- Stacked on #80 (`feature/core-eval-tests`); retarget to `main` after the stack merges. Diff vs stack top: 9 files, +239/−3.
- KNN validation ran with `use_faiss=False` — faiss-cpu 1.13.2 crashes in `IndexFlatIP.search` at scale (TAO-2387).
- ADE20K seg validation is TAO-2384 (blocked: dataset not on the devbox).
- One rebase conflict was resolved when moving to GitHub `main` (`config/dinov3/default_config.py`): kept main's newer `DINOv3ExportExpConfig` and added the `evaluate` field — worth a second look.

---
_Migrated from GitLab MR nvidia-tao-toolkit/tao-pytorch!645, rebased onto GitHub `main`._