### PR TITLE
build: add tao-core submodule (pinned to latest main)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tao-core"]
+	path = tao-core
+	url = https://github.com/NVIDIA-TAO/tao-core.git
+	branch = main


### PR DESCRIPTION
Adds `tao-core` as a submodule at `tao-core/`, tracking main, pinned to `825f2140`. Same pattern as NVIDIA-TAO/tao-deploy#30; the submodule-aware `cloneGithubSource` (now on library main) inits it at the pinned SHA. For review — running /build to verify.