### PR TITLE
[TAO-2489][Feature] DINOv3: load HuggingFace-format checkpoints

### DIFF
--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -43,7 +43,9 @@ from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
 )
 from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
     TAO_ONLY_KEYS,
+    convert_hf_to_tao,
     fuse_timm_swiglu_fc1,
+    is_hf_dinov3_state_dict,
     merge_lora_state_dict,
     timm_to_tao,
 )
@@ -652,23 +654,35 @@ class DinoV3PlModel(DinoV2PlModel):
 
     @staticmethod
     def _remap_dinov3_state_dict(timm_state_dict, reference_state_dict):
-        """Translate timm DINOv3 ViT keys to ``DinoV3VisionTransformer`` keys.
+        """Translate a public DINOv3 checkpoint's keys to ``DinoV3VisionTransformer`` keys.
 
-        Renames the LayerScale gammas (``blocks.N.gamma_1/2`` -> ``blocks.N.ls1/ls2.gamma``)
-        and the register parameter (``reg_token`` -> ``register_tokens``); all other keys
-        (``cls_token``, ``patch_embed.proj.*``, ``blocks.N.{norm1,norm2,attn.qkv,attn.proj,
-        mlp.fc1,mlp.fc2}.*``, ``norm.*``) map by identity. timm carries no ``pos_embed`` (RoPE
-        replaces it) and no QKV bias. Only keys present in the reference state dict with a
-        matching shape are kept.
+        Accepts either public serialization of the same weights:
+
+        * **timm** (default): renames the LayerScale gammas (``blocks.N.gamma_1/2`` ->
+          ``blocks.N.ls1/ls2.gamma``) and the register parameter (``reg_token`` ->
+          ``register_tokens``); all other keys map by identity.
+        * **HuggingFace** ``DINOv3ViTModel``: detected by its ``embeddings.*`` / ``layer.N.*``
+          keys and converted up front, which also fuses the separate q/k/v projections into the
+          ``attn.qkv`` this ViT expects. Without that pass an HF file matches only ``norm.weight``
+          and ``norm.bias`` -- 2 of 211 tensors -- and training would start from an almost
+          entirely random backbone while still logging a successful load.
+
+        timm carries no ``pos_embed`` (RoPE replaces it) and no QKV bias. Only keys present in
+        the reference state dict with a matching shape are kept.
 
         Args:
-            timm_state_dict (dict): Source timm/Meta DINOv3 state dict.
+            timm_state_dict (dict): Source timm/Meta/HF DINOv3 state dict.
             reference_state_dict (dict): ``self.student.backbone.state_dict()`` (target keys).
 
         Returns:
             Tuple[dict, list]: ``(remapped, unmapped)`` where ``remapped`` is loadable into
             the backbone and ``unmapped`` lists source keys that had no shape-matching target.
         """
+        # HuggingFace layout: rename + fuse q/k/v before anything else, so the rest of this
+        # function sees ordinary timm-style keys.
+        if is_hf_dinov3_state_dict(timm_state_dict):
+            timm_state_dict = convert_hf_to_tao(timm_state_dict)
+
         # Source carries adapters but the destination backbone cannot hold them (inference,
         # export, or the start of a fresh run before injection): fold them into the base so the
         # weights loaded are the *adapted* model. Without this the adapter keys are simply

--- a/nvidia_tao_pytorch/ssl/dinov3/utils/checkpoint_remap.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/utils/checkpoint_remap.py
@@ -100,6 +100,135 @@ def tao_to_timm(key):
     return key
 
 
+# ---------------------------------------------------------------------------------------
+# HuggingFace ``DINOv3ViTModel`` -> TAO
+#
+# The HF export carries the *same weights* as the timm release -- verified bit-exact:
+# ``cat([q_proj, k_proj, v_proj])`` equals timm's fused ``attn.qkv.weight`` with zero
+# difference, as do ``patch_embed`` and ``cls_token``. Only the serialization differs, in two
+# ways the timm remapper cannot express:
+#
+#   1. Different names throughout (``embeddings.*`` / ``layer.N.*`` rather than bare / ``blocks.N.*``).
+#      Under the timm rules exactly two keys coincide -- ``norm.weight`` / ``norm.bias`` -- which
+#      is why an HF checkpoint used to load 2 of 211 tensors and train from a near-random backbone.
+#   2. Attention stored as **separate** q/k/v projections rather than a fused ``qkv``. That is a
+#      tensor transform, not a rename, so it needs its own pass (cf. ``fuse_timm_swiglu_fc1``).
+#
+# Bonus: the HF export includes ``mask_token``, which the timm release omits (TAO otherwise
+# initializes it randomly for iBOT).
+# ---------------------------------------------------------------------------------------
+
+# Exact full-key renames, HF name -> TAO name.
+_EXACT_HF_TO_TAO = {
+    "embeddings.cls_token": "cls_token",
+    "embeddings.mask_token": "mask_token",
+    "embeddings.register_tokens": "register_tokens",
+    "embeddings.patch_embeddings.weight": "patch_embed.proj.weight",
+    "embeddings.patch_embeddings.bias": "patch_embed.proj.bias",
+}
+# Per-block suffix renames, HF suffix -> TAO suffix (applied after ``layer.N`` -> ``blocks.N``).
+_SUFFIX_HF_TO_TAO = {
+    ".attention.o_proj": ".attn.proj",
+    ".layer_scale1.lambda1": ".ls1.gamma",
+    ".layer_scale2.lambda1": ".ls2.gamma",
+    ".mlp.up_proj": ".mlp.fc1",
+    ".mlp.down_proj": ".mlp.fc2",
+}
+# HF attention biases that TAO/timm deliberately do not have. DINOv3 ships these as all-zero
+# (the config advertises query/value bias, but the tensors are zero), so dropping them is
+# lossless -- ``convert_hf_to_tao`` asserts that rather than assuming it.
+_HF_DROPPED_BIASES = (".attention.q_proj.bias", ".attention.k_proj.bias", ".attention.v_proj.bias")
+
+
+def is_hf_dinov3_state_dict(state_dict):
+    """Whether a state dict is a HuggingFace ``DINOv3ViTModel`` export.
+
+    Args:
+        state_dict (Mapping): Candidate state dict.
+
+    Returns:
+        bool: True for the HF layout (``embeddings.*`` / ``layer.N.*`` keys).
+    """
+    keys = list(state_dict)
+    return any(k.startswith("embeddings.") for k in keys) and any(
+        k.startswith("layer.") for k in keys
+    )
+
+
+def hf_to_tao(key):
+    """Translate a HuggingFace DINOv3 parameter name to the TAO ``ssl/dinov3`` name.
+
+    Does not handle the q/k/v fusion, which is not a rename; see :func:`convert_hf_to_tao`.
+
+    Args:
+        key (str): HF-side parameter name.
+
+    Returns:
+        str: TAO-side parameter name (unchanged if no rule applies).
+    """
+    if key in _EXACT_HF_TO_TAO:
+        return _EXACT_HF_TO_TAO[key]
+    if key.startswith("layer."):
+        key = "blocks." + key[len("layer."):]
+    for src, dst in _SUFFIX_HF_TO_TAO.items():
+        if src in key:
+            key = key.replace(src, dst)
+            break
+    return key
+
+
+def convert_hf_to_tao(hf_state_dict, strict_zero_bias=True):
+    """Convert a HuggingFace DINOv3 state dict into TAO ``ssl/dinov3`` naming and layout.
+
+    Renames every key, fuses the separate ``q_proj``/``k_proj``/``v_proj`` weights into the
+    single ``blocks.N.attn.qkv.weight`` that the TAO ViT expects, and drops the q/k/v biases
+    that the TAO/timm architecture does not carry.
+
+    Args:
+        hf_state_dict (Mapping): State dict in HuggingFace ``DINOv3ViTModel`` layout.
+        strict_zero_bias (bool): If True, assert the dropped q/k/v biases are all zero. DINOv3
+            ships them zero, so a nonzero value means the checkpoint genuinely needs a
+            bias-carrying attention and silently discarding it would corrupt the model.
+
+    Returns:
+        dict: State dict in TAO naming, loadable into ``DinoV3VisionTransformer``.
+
+    Raises:
+        ValueError: If ``strict_zero_bias`` and a dropped bias is nonzero, or if a block has an
+            incomplete q/k/v triple.
+    """
+    out = {}
+    block_ids = sorted(
+        {int(k.split(".")[1]) for k in hf_state_dict if k.startswith("layer.")}
+    )
+
+    for block in block_ids:
+        parts = []
+        for proj in ("q_proj", "k_proj", "v_proj"):
+            name = f"layer.{block}.attention.{proj}.weight"
+            if name not in hf_state_dict:
+                raise ValueError(
+                    f"HF checkpoint is missing {name}; cannot fuse block {block}'s attention."
+                )
+            parts.append(hf_state_dict[name])
+        out[f"blocks.{block}.attn.qkv.weight"] = torch.cat(parts, dim=0).contiguous()
+
+    for key, weight in hf_state_dict.items():
+        if ".attention.q_proj.weight" in key or ".attention.k_proj.weight" in key or \
+                ".attention.v_proj.weight" in key:
+            continue  # already fused above
+        if any(dropped in key for dropped in _HF_DROPPED_BIASES):
+            if strict_zero_bias and weight.abs().max().item() > 0:
+                raise ValueError(
+                    f"HF checkpoint has a nonzero {key} but the TAO/timm DINOv3 attention has no "
+                    "qkv bias. Dropping it would change the model; refusing to convert silently."
+                )
+            continue
+        out[hf_to_tao(key)] = weight.contiguous()
+
+    return out
+
+
 def fuse_timm_swiglu_fc1(timm_state_dict):
     """Fuse timm's split SwiGLU projections into the ``GluMlp`` fused ``fc1``.
 

--- a/tests/ssl_unit_test/dinov3/test_hf_checkpoint.py
+++ b/tests/ssl_unit_test/dinov3/test_hf_checkpoint.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Loading HuggingFace-format DINOv3 checkpoints.
+
+The HF ``DINOv3ViTModel`` export holds the same weights as the timm release but serializes
+them differently: ``embeddings.*`` / ``layer.N.*`` names, and attention stored as separate
+``q_proj``/``k_proj``/``v_proj`` rather than a fused ``qkv``. Under the timm rules alone exactly
+two keys coincide (``norm.weight``/``norm.bias``), so an HF checkpoint used to load 2 of 211
+tensors and train from a near-random backbone while still logging a successful load.
+"""
+
+import pytest
+import torch
+
+from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
+    convert_hf_to_tao,
+    hf_to_tao,
+    is_hf_dinov3_state_dict,
+)
+
+EMBED_DIM = 64
+N_BLOCKS = 2
+
+
+def _fake_hf_state_dict(n_blocks=N_BLOCKS, dim=EMBED_DIM, qv_bias_value=0.0):
+    """Build a minimal state dict in HuggingFace ``DINOv3ViTModel`` layout."""
+    torch.manual_seed(0)
+    sd = {
+        "embeddings.cls_token": torch.randn(1, 1, dim),
+        "embeddings.mask_token": torch.randn(1, 1, dim),
+        "embeddings.register_tokens": torch.randn(1, 4, dim),
+        "embeddings.patch_embeddings.weight": torch.randn(dim, 3, 16, 16),
+        "embeddings.patch_embeddings.bias": torch.randn(dim),
+        "norm.weight": torch.randn(dim),
+        "norm.bias": torch.randn(dim),
+    }
+    for b in range(n_blocks):
+        p = f"layer.{b}."
+        for proj in ("q_proj", "k_proj", "v_proj"):
+            sd[f"{p}attention.{proj}.weight"] = torch.randn(dim, dim)
+        for proj in ("q_proj", "v_proj"):
+            sd[f"{p}attention.{proj}.bias"] = torch.full((dim,), qv_bias_value)
+        sd[f"{p}attention.o_proj.weight"] = torch.randn(dim, dim)
+        sd[f"{p}attention.o_proj.bias"] = torch.randn(dim)
+        sd[f"{p}layer_scale1.lambda1"] = torch.randn(dim)
+        sd[f"{p}layer_scale2.lambda1"] = torch.randn(dim)
+        sd[f"{p}mlp.up_proj.weight"] = torch.randn(4 * dim, dim)
+        sd[f"{p}mlp.up_proj.bias"] = torch.randn(4 * dim)
+        sd[f"{p}mlp.down_proj.weight"] = torch.randn(dim, 4 * dim)
+        sd[f"{p}mlp.down_proj.bias"] = torch.randn(dim)
+        sd[f"{p}norm1.weight"] = torch.randn(dim)
+        sd[f"{p}norm1.bias"] = torch.randn(dim)
+        sd[f"{p}norm2.weight"] = torch.randn(dim)
+        sd[f"{p}norm2.bias"] = torch.randn(dim)
+    return sd
+
+
+@pytest.mark.ssl_unit
+def test_hf_format_detection():
+    """HF exports are recognized; timm ones are not."""
+    assert is_hf_dinov3_state_dict(_fake_hf_state_dict())
+    timm_like = {"cls_token": torch.zeros(1), "blocks.0.attn.qkv.weight": torch.zeros(1),
+                 "norm.weight": torch.zeros(1)}
+    assert not is_hf_dinov3_state_dict(timm_like)
+
+
+@pytest.mark.ssl_unit
+def test_hf_key_renames():
+    """Every HF name maps onto its TAO counterpart."""
+    cases = {
+        "embeddings.cls_token": "cls_token",
+        "embeddings.mask_token": "mask_token",
+        "embeddings.register_tokens": "register_tokens",
+        "embeddings.patch_embeddings.weight": "patch_embed.proj.weight",
+        "layer.3.attention.o_proj.bias": "blocks.3.attn.proj.bias",
+        "layer.3.layer_scale1.lambda1": "blocks.3.ls1.gamma",
+        "layer.3.layer_scale2.lambda1": "blocks.3.ls2.gamma",
+        "layer.3.mlp.up_proj.weight": "blocks.3.mlp.fc1.weight",
+        "layer.3.mlp.down_proj.bias": "blocks.3.mlp.fc2.bias",
+        "layer.3.norm1.weight": "blocks.3.norm1.weight",
+        "norm.weight": "norm.weight",
+    }
+    for src, want in cases.items():
+        assert hf_to_tao(src) == want, f"{src} -> {hf_to_tao(src)}, expected {want}"
+
+
+@pytest.mark.ssl_unit
+def test_hf_qkv_fusion_is_concatenation():
+    """q/k/v fuse into one ``attn.qkv`` in q,k,v order — the transform a rename cannot do."""
+    hf = _fake_hf_state_dict()
+    tao = convert_hf_to_tao(hf)
+
+    fused = tao["blocks.0.attn.qkv.weight"]
+    assert fused.shape == (3 * EMBED_DIM, EMBED_DIM)
+    q, k, v = (hf[f"layer.0.attention.{p}.weight"] for p in ("q_proj", "k_proj", "v_proj"))
+    torch.testing.assert_close(fused, torch.cat([q, k, v], dim=0), rtol=0, atol=0)
+
+    # The separate projections must not survive alongside the fused tensor.
+    assert not [key for key in tao if "q_proj" in key or "k_proj" in key or "v_proj" in key]
+
+
+@pytest.mark.ssl_unit
+def test_hf_zero_qv_bias_is_dropped():
+    """DINOv3 ships all-zero q/v biases, which TAO's bias-free attention simply drops."""
+    tao = convert_hf_to_tao(_fake_hf_state_dict(qv_bias_value=0.0))
+    assert not [k for k in tao if k.endswith("attn.qkv.bias")]
+    # The output projection's bias, which TAO *does* have, is preserved.
+    assert "blocks.0.attn.proj.bias" in tao
+
+
+@pytest.mark.ssl_unit
+def test_hf_nonzero_qv_bias_refuses_to_convert():
+    """A nonzero q/v bias cannot be represented, so it must fail loudly rather than vanish."""
+    with pytest.raises(ValueError, match="nonzero"):
+        convert_hf_to_tao(_fake_hf_state_dict(qv_bias_value=0.5))
+
+
+@pytest.mark.ssl_unit
+def test_hf_conversion_covers_every_key():
+    """No HF tensor is silently lost apart from the deliberately dropped zero biases."""
+    hf = _fake_hf_state_dict()
+    tao = convert_hf_to_tao(hf)
+    dropped = [k for k in hf if k.endswith(("q_proj.bias", "v_proj.bias"))]
+    fused_away = [k for k in hf if k.endswith(("q_proj.weight", "k_proj.weight", "v_proj.weight"))]
+    # every source key is either renamed, fused, or an intentionally dropped bias
+    assert len(tao) == len(hf) - len(dropped) - len(fused_away) + N_BLOCKS
+    assert "mask_token" in tao, "HF ships mask_token; timm does not, so it must survive"

--- a/tests/ssl_unit_test/dinov3/test_lora.py
+++ b/tests/ssl_unit_test/dinov3/test_lora.py
@@ -1,0 +1,663 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DINOv3 LoRA unit tests — the Stage-1 gate ladder (G1.1 – G1.7).
+
+Each test maps to one invariant from ``docs/plans/dinov3_lora_devbox_plan.md``:
+
+======  ==============================================================================
+G1.1    Identity: injected LoRA (B=0) forward == stock forward
+G1.2    Merge parity: forward(merge(m)) ~= forward(m) after random A/B
+G1.3    EMA alignment: student/teacher ``named_parameters()`` name lists identical
+G1.4    Freeze audit: ``requires_grad`` true only for ``lora_*``, heads, ``mask_token``
+G1.5    Key stability: backbone keys == stock keys + ``lora_*``; timm round-trip unaffected
+G1.6    Gram-teacher sync with a LoRA-injected teacher succeeds
+G1.7    Optimizer groups: LoRA params land in the right ``blocks.N`` layer-id groups
+======  ==============================================================================
+
+The backbone tests build a *tiny* ViT (2 blocks, 64-dim) on CPU in fp32 and disable
+``use_custom_attention``: the xformers ``memory_efficient_attention`` path hard-casts q/k/v to
+``.half()``, which would swamp the 1e-6 identity tolerance these gates are about.
+"""
+
+import pytest
+from omegaconf import OmegaConf
+import torch
+from torch import nn
+from pytorch_lightning.strategies.single_device import SingleDeviceStrategy
+
+from nvidia_tao_pytorch.config.dinov3.default_config import ExperimentConfig
+from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
+    LoRALinear,
+    inject_lora,
+    merge_lora,
+    has_lora,
+    is_lora_key,
+    strip_lora_keys,
+    lora_parameter_report,
+)
+from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
+from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer
+from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import timm_to_tao, tao_to_timm
+
+# Tiny ViT so the whole gate ladder runs on CPU in seconds.
+TINY = dict(
+    img_size=32, patch_size=16, embed_dim=64, depth=2, num_heads=4,
+    init_values=1e-5, drop_path_schedule="uniform", num_classes=0,
+    drop_path_rate=0.0, register_tokens=2, use_custom_attention=False,
+)
+BATCH_SIZE = 2
+RANK = 4
+ALPHA = 8.0
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA GPU")
+
+
+def _tiny_backbone(seed=0):
+    """Build a small fp32 DINOv3 ViT on CPU for the structural gates."""
+    torch.manual_seed(seed)
+    return DinoV3VisionTransformer(**TINY).eval()
+
+
+def _tiny_input():
+    """Deterministic image batch matching the tiny ViT's input size."""
+    torch.manual_seed(123)
+    return torch.randn(BATCH_SIZE, 3, TINY["img_size"], TINY["img_size"])
+
+
+def _randomize_lora_(module):
+    """Give every adapter a non-trivial B (init is zero, i.e. identity)."""
+    generator = torch.Generator().manual_seed(7)
+    for submodule in module.modules():
+        if isinstance(submodule, LoRALinear):
+            with torch.no_grad():
+                submodule.lora_A.copy_(torch.randn(submodule.lora_A.shape, generator=generator) * 0.05)
+                submodule.lora_B.copy_(torch.randn(submodule.lora_B.shape, generator=generator) * 0.05)
+
+
+# --------------------------------------------------------------------------------------
+# G1.1 — identity at init
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_lora_linear_is_identity_at_init():
+    """A freshly wrapped LoRALinear reproduces its base nn.Linear bit-for-bit (B=0)."""
+    torch.manual_seed(0)
+    base = nn.Linear(32, 16)
+    x = torch.randn(4, 32)
+    expected = base(x)
+
+    lora = LoRALinear.from_linear(base, rank=RANK, alpha=ALPHA, dropout=0.0)
+
+    # The adopted Parameter objects are the *same* tensors, not copies.
+    assert lora.weight is base.weight
+    assert lora.bias is base.bias
+    assert torch.equal(lora.lora_B, torch.zeros_like(lora.lora_B))
+    torch.testing.assert_close(lora(x), expected, rtol=0, atol=0)
+
+
+@pytest.mark.ssl_unit
+def test_injection_identity():
+    """G1.1: injecting LoRA into a backbone leaves its forward unchanged (<=1e-6)."""
+    backbone = _tiny_backbone()
+    x = _tiny_input()
+    with torch.no_grad():
+        before = backbone(x)
+
+    injected = inject_lora(backbone, rank=RANK, alpha=ALPHA, dropout=0.0)
+    assert injected, "expected at least one LoRA target to be injected"
+    assert has_lora(backbone)
+
+    with torch.no_grad():
+        after = backbone(x)
+
+    for key in ("x_norm_clstoken", "x_norm_patchtokens"):
+        torch.testing.assert_close(after[key], before[key], rtol=1e-6, atol=1e-6)
+
+
+# --------------------------------------------------------------------------------------
+# G1.2 — merge parity
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_merge_parity():
+    """G1.2: after random A/B, merging folds the delta in without changing the forward."""
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA, dropout=0.0)
+    _randomize_lora_(backbone)
+
+    x = _tiny_input()
+    with torch.no_grad():
+        unmerged = backbone(x)
+
+    # Sanity: the randomized adapter actually changed the function, so parity is meaningful.
+    stock = _tiny_backbone()
+    with torch.no_grad():
+        stock_out = stock(x)
+    assert not torch.allclose(unmerged["x_norm_clstoken"], stock_out["x_norm_clstoken"], atol=1e-5), \
+        "randomized LoRA did not perturb the backbone; merge parity would be vacuous"
+
+    merged_count = merge_lora(backbone)
+    assert merged_count == len(list(m for m in backbone.modules() if isinstance(m, LoRALinear)))
+
+    with torch.no_grad():
+        merged = backbone(x)
+
+    for key in ("x_norm_clstoken", "x_norm_patchtokens"):
+        torch.testing.assert_close(merged[key], unmerged[key], rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.ssl_unit
+def test_merge_is_idempotent_and_matches_delta_weight():
+    """Merging twice is a no-op, and the folded delta equals (alpha/r) * B @ A."""
+    torch.manual_seed(0)
+    base = nn.Linear(16, 8, bias=False)
+    lora = LoRALinear.from_linear(base, rank=RANK, alpha=ALPHA)
+    original_weight = lora.weight.detach().clone()
+    _randomize_lora_(lora)
+
+    expected_delta = lora.delta_weight().detach().clone()
+    lora.merge()
+    torch.testing.assert_close(lora.weight.data - original_weight, expected_delta, rtol=1e-6, atol=1e-6)
+
+    weight_after_first = lora.weight.detach().clone()
+    lora.merge()  # idempotent
+    torch.testing.assert_close(lora.weight.data, weight_after_first, rtol=0, atol=0)
+
+
+# --------------------------------------------------------------------------------------
+# G1.5 — key stability
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_state_dict_keys():
+    """G1.5: injection adds only lora_* keys; every stock key survives unchanged."""
+    stock_keys = set(_tiny_backbone().state_dict())
+
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+    injected_keys = set(backbone.state_dict())
+
+    added = injected_keys - stock_keys
+    assert not (stock_keys - injected_keys), "injection dropped stock backbone keys"
+    assert added, "injection added no keys"
+    assert all(is_lora_key(k) for k in added), f"non-LoRA keys appeared: {sorted(added - set(filter(is_lora_key, added)))}"
+    assert strip_lora_keys(backbone.state_dict()).keys() == stock_keys
+
+    # Three lora entries per injected module: lora_A, lora_B and the persisted scale.
+    n_lora_modules = sum(1 for m in backbone.modules() if isinstance(m, LoRALinear))
+    assert len(added) == 3 * n_lora_modules
+
+
+@pytest.mark.ssl_unit
+def test_convert_merges_adapters_into_exported_weights(tmp_path):
+    """End-to-end: `dinov3 convert` must export the *adapted* weights, not the frozen base.
+
+    Exercises the real converter rather than stripping adapter keys in the test. With nonzero
+    A/B the exported weight must equal ``W + (alpha/r) * B @ A`` and no ``lora_*`` key may
+    survive -- previously the adapters either failed timm validation or were written straight
+    into a supposedly timm-format file, and export silently shipped the unadapted model.
+    """
+    from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import convert_ssl_to_timm
+
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+    _randomize_lora_(backbone)
+
+    # Expected merged weights, computed independently of the converter.
+    expected = {}
+    for name, module in backbone.named_modules():
+        if isinstance(module, LoRALinear):
+            expected[f"{name}.weight"] = (
+                module.weight.detach() + module.delta_weight().detach()
+            ).clone()
+    assert expected, "no adapters to merge; the test would be vacuous"
+
+    src = tmp_path / "ssl_ckpt.pth"
+    dst = tmp_path / "backbone.safetensors"
+    torch.save({"state_dict": {f"teacher.backbone.{k}": v
+                               for k, v in backbone.state_dict().items()}}, src)
+
+    converted = convert_ssl_to_timm(
+        str(src), str(dst), source="teacher", validate=False,
+        timm_model_name="vit_small_patch16_dinov3",
+    )
+
+    assert not [k for k in converted if is_lora_key(k)], "lora_* keys leaked into the export"
+    for key, want in expected.items():
+        assert key in converted, f"{key} missing from the converted backbone"
+        torch.testing.assert_close(converted[key], want, rtol=1e-6, atol=1e-6)
+
+    # And the merge must have actually changed something relative to the frozen base.
+    stock = _tiny_backbone().state_dict()
+    changed = [k for k in expected if not torch.allclose(converted[k], stock[k], atol=1e-6)]
+    assert changed, "converted weights equal the frozen base; the adapters were not applied"
+
+
+@pytest.mark.ssl_unit
+def test_timm_remap_roundtrip_unaffected_by_lora():
+    """G1.5: the timm<->TAO key translation is untouched for base keys, and skips lora keys."""
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+
+    for key in strip_lora_keys(backbone.state_dict()):
+        assert timm_to_tao(tao_to_timm(key)) == key, f"round-trip broke for {key}"
+
+    # LoRA keys are recognized as adapter keys, so convert can merge/drop them before
+    # translation. `lora_scaling` is the persisted alpha/rank buffer and counts as one.
+    lora_keys = [k for k in backbone.state_dict() if is_lora_key(k)]
+    assert lora_keys and all(
+        k.endswith(("lora_A", "lora_B", "lora_scaling")) for k in lora_keys
+    ), sorted(lora_keys)
+
+
+@pytest.mark.ssl_unit
+def test_num_last_blocks_and_target_modules_are_respected():
+    """Only the requested projections in the requested blocks get adapters."""
+    backbone = _tiny_backbone()
+    injected = inject_lora(backbone, rank=RANK, alpha=ALPHA,
+                           target_modules=["qkv"], num_last_blocks=1)
+
+    assert injected == ["blocks.1.attn.qkv"]
+    assert isinstance(backbone.blocks[1].attn.qkv, LoRALinear)
+    assert not isinstance(backbone.blocks[1].attn.proj, LoRALinear)
+    assert not isinstance(backbone.blocks[0].attn.qkv, LoRALinear)
+
+
+@pytest.mark.ssl_unit
+def test_injection_is_idempotent():
+    """Re-injecting must not disarm adapters added by an earlier call.
+
+    Freezing the whole backbone on every call switched off existing ``lora_A``/``lora_B``,
+    and since already-injected modules are skipped nothing turned them back on -- so a second
+    call, or a staged ``qkv`` then ``proj`` injection, silently trained only the heads.
+    """
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+    after_first = {n for n, p in backbone.named_parameters() if p.requires_grad}
+
+    second = inject_lora(backbone, rank=RANK, alpha=ALPHA)
+    after_second = {n for n, p in backbone.named_parameters() if p.requires_grad}
+
+    assert second == [], "second injection should find every target already adapted"
+    assert after_second == after_first, (
+        f"trainable set changed on re-injection; lost {sorted(after_first - after_second)}"
+    )
+
+    # Staged injection: adapting qkv first then proj must leave both trainable.
+    staged = _tiny_backbone()
+    inject_lora(staged, rank=RANK, alpha=ALPHA, target_modules=["qkv"])
+    inject_lora(staged, rank=RANK, alpha=ALPHA, target_modules=["proj"])
+    trainable = {n for n, p in staged.named_parameters() if p.requires_grad}
+    assert [n for n in trainable if "qkv.lora" in n], "qkv adapters were frozen by the proj pass"
+    assert [n for n in trainable if "proj.lora" in n], "proj adapters are not trainable"
+
+
+@pytest.mark.ssl_unit
+def test_unknown_target_module_raises():
+    """A typo in target_modules fails loudly rather than silently adapting nothing."""
+    with pytest.raises(ValueError, match="Unknown LoRA target_modules"):
+        inject_lora(_tiny_backbone(), target_modules=["qkv", "not_a_projection"])
+
+
+# --------------------------------------------------------------------------------------
+# G1.4 — freeze audit (backbone level)
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_backbone_freeze_audit():
+    """G1.4: inside the backbone only lora_* and mask_token stay trainable."""
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+
+    trainable = {n for n, p in backbone.named_parameters() if p.requires_grad}
+    expected = {n for n, _ in backbone.named_parameters() if is_lora_key(n)} | {"mask_token"}
+    assert trainable == expected, f"unexpected trainable set: {sorted(trainable ^ expected)}"
+
+
+@pytest.mark.ssl_unit
+def test_lora_parameter_report_counts_adapters():
+    """The trainable-param report (gate G2.7's log line) counts adapters correctly."""
+    backbone = _tiny_backbone()
+    inject_lora(backbone, rank=RANK, alpha=ALPHA)
+    stats = lora_parameter_report(backbone, name="tiny")
+
+    expected_lora = sum(p.numel() for n, p in backbone.named_parameters() if is_lora_key(n))
+    assert stats["lora"] == expected_lora > 0
+    assert stats["trainable"] == expected_lora + backbone.mask_token.numel()
+    assert 0.0 < stats["trainable_fraction"] < 1.0
+
+
+# --------------------------------------------------------------------------------------
+# Full-model gates (G1.3, G1.4, G1.6, G1.7) — need the PL model, hence CUDA.
+# --------------------------------------------------------------------------------------
+
+def _lora_experiment_config(gram=True, preservation=True, backbone="vit_s"):
+    """Build a small-but-real DINOv3 experiment config with LoRA enabled."""
+    config = OmegaConf.structured(ExperimentConfig())
+    config.model.backbone.student_type = backbone
+    config.model.backbone.teacher_type = backbone
+    config.model.lora.enable = True
+    config.model.lora.rank = RANK
+    config.model.lora.alpha = ALPHA
+    config.model.lora.dropout = 0.0
+    config.model.gram.enable = gram
+    config.model.gram.w_gram = 1.0 if gram else 0.0
+    config.model.preservation.enable = preservation
+    return config
+
+
+@pytest.mark.ssl_unit
+def test_ema_zip_alignment():
+    """G1.3: student and teacher expose identical parameter names *and shapes* after injection.
+
+    ``update_teacher`` zips ``student.parameters()`` with ``teacher.parameters()``
+    element-wise, so any asymmetry in injection silently corrupts the EMA.
+    """
+    model = DinoV3PlModel(_lora_experiment_config())
+    model.inject_lora_adapters()
+
+    student_names = [n for n, _ in model.student.named_parameters()]
+    teacher_names = [n for n, _ in model.teacher.named_parameters()]
+    assert student_names == teacher_names
+
+    for (name, student_param), (_, teacher_param) in zip(
+        model.student.named_parameters(), model.teacher.named_parameters()
+    ):
+        assert student_param.shape == teacher_param.shape, f"shape mismatch at {name}"
+
+    # The teacher must start *equal* to the student, else its adapter is not an EMA of the
+    # student's (gate G2.4 at step 0). lora_A is randomly initialized, so this is a real check.
+    student_state = model.student.backbone.state_dict()
+    teacher_state = model.teacher.backbone.state_dict()
+    for key, value in student_state.items():
+        torch.testing.assert_close(teacher_state[key], value, rtol=0, atol=0,
+                                   msg=lambda m, k=key: f"teacher != student at {k}: {m}")
+    assert any(is_lora_key(k) for k in student_state)
+
+
+@pytest.mark.ssl_unit
+def test_trainable_set():
+    """G1.4: across the whole student, only lora_*, the heads and mask_token get gradients."""
+    model = DinoV3PlModel(_lora_experiment_config())
+    model.inject_lora_adapters()
+
+    for name, param in model.student.named_parameters():
+        should_train = (
+            is_lora_key(name) or
+            name.startswith(("dino_head.", "ibot_head.")) or
+            name == "backbone.mask_token"
+        )
+        assert param.requires_grad == should_train, (
+            f"{name}: requires_grad={param.requires_grad}, expected {should_train}"
+        )
+
+    # The EMA teacher is never gradient-updated, adapters included.
+    assert not any(p.requires_grad for p in model.teacher.parameters())
+    # The frozen anchor teacher gets no LoRA at all.
+    assert not has_lora(model.gram_teacher)
+    assert not any(p.requires_grad for p in model.gram_teacher.parameters())
+
+
+@pytest.mark.ssl_unit
+def test_update_teacher_leaves_frozen_base_bit_exact():
+    """The EMA must not touch frozen base weights under LoRA (Stage-2 G2.3 regression).
+
+    ``m*W + (1-m)*W`` is a no-op in exact arithmetic but not in floating point, so the
+    inherited all-parameter EMA slowly drifted the teacher's "frozen" base away from the
+    student's. Here one update with a realistic momentum must leave every base tensor
+    bit-identical while still moving the adapters.
+    """
+    model = DinoV3PlModel(_lora_experiment_config())
+    model.inject_lora_adapters()
+
+    # update_teacher consults trainer.strategy; stand in for a single-device run.
+    class _Trainer:
+        strategy = SingleDeviceStrategy()
+    model.trainer = _Trainer()
+
+    # Move the student's trainable params so the EMA has something real to track.
+    with torch.no_grad():
+        for name, param in model.student.named_parameters():
+            if param.requires_grad:
+                param.add_(torch.randn_like(param) * 0.01)
+
+    before = {n: p.detach().clone() for n, p in model.teacher.named_parameters()}
+    model.update_teacher(0.9999)
+
+    drifted, moved = [], []
+    for name, param in model.teacher.named_parameters():
+        changed = not torch.equal(param, before[name])
+        if is_lora_key(name) or name.startswith(("dino_head.", "ibot_head.")) or \
+                name == "backbone.mask_token":
+            if changed:
+                moved.append(name)
+        elif changed:
+            drifted.append(name)
+
+    assert not drifted, f"frozen base tensors changed during EMA: {drifted[:5]}"
+    assert moved, "EMA did not update any trainable parameter"
+
+
+@pytest.mark.ssl_unit
+def test_gram_sync_lora():
+    """G1.6: syncing a LoRA-injected teacher into the un-injected anchor teacher works."""
+    model = DinoV3PlModel(_lora_experiment_config())
+    model.inject_lora_adapters()
+
+    # Perturb the teacher's base weights so a successful sync is observable.
+    with torch.no_grad():
+        model.teacher.backbone.cls_token.add_(1.0)
+    _randomize_lora_(model.teacher.backbone)
+
+    model._sync_gram_teacher()  # must not raise on the lora_* keys
+
+    torch.testing.assert_close(
+        model.gram_teacher.cls_token, model.teacher.backbone.cls_token, rtol=0, atol=0
+    )
+    assert not has_lora(model.gram_teacher)
+    assert set(model.gram_teacher.state_dict()) == set(
+        strip_lora_keys(model.teacher.backbone.state_dict())
+    )
+
+
+@pytest.mark.ssl_unit
+def test_optim_groups():
+    """G1.7: LoRA params land in the correct blocks.N layer-id groups; no frozen params appear."""
+    model = DinoV3PlModel(_lora_experiment_config())
+    model.inject_lora_adapters()
+
+    optimizer = model.configure_optimizers()
+    grouped = {id(p) for group in optimizer.param_groups for p in group["params"]}
+
+    trainable = {id(p) for p in model.student.parameters() if p.requires_grad}
+    frozen = {id(p) for p in model.student.parameters() if not p.requires_grad}
+
+    assert grouped == trainable, "optimizer groups do not match the trainable set"
+    assert not (grouped & frozen), "frozen params leaked into an optimizer group"
+
+    # Layer-id decay: a LoRA param in block N must get the same lr_multiplier as that block's
+    # base weights would, i.e. the `int(after_block[0])` fallback in configure_optimizers fires.
+    n_blocks = model.student.backbone.n_blocks
+    multiplier_by_lora_param = {}
+    for group in optimizer.param_groups:
+        for param in group["params"]:
+            multiplier_by_lora_param[id(param)] = group["lr_multiplier"]
+
+    for name, param in model.student.named_parameters():
+        if not is_lora_key(name):
+            continue
+        block_index = int(name.split(".blocks.")[-1].split(".")[0])
+        expected = model.layerwise_decay ** (n_blocks + 1 - (block_index + 1))
+        assert multiplier_by_lora_param[id(param)] == pytest.approx(expected), (
+            f"{name} landed in the wrong layer-id group"
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Config plumbing and guardrails
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_lora_and_preservation_config_defaults():
+    """The new config fields exist with the documented defaults."""
+    config = OmegaConf.structured(ExperimentConfig())
+
+    assert config.model.lora.enable is False
+    assert config.model.lora.rank == 8
+    assert config.model.lora.alpha == 16.0
+    assert config.model.lora.dropout == 0.05
+    assert list(config.model.lora.target_modules) == ["qkv", "proj"]
+    assert config.model.lora.num_last_blocks == 0
+
+    assert config.model.preservation.enable is False
+    assert config.model.preservation.cls_mse_weight == 0.05
+    assert config.model.preservation.cls_cosine_weight == 0.05
+
+
+@pytest.mark.ssl_unit
+def test_anchor_teacher_builds_for_preservation_without_gram():
+    """The anchor teacher must exist when preservation alone is on (gram disabled)."""
+    model = DinoV3PlModel(_lora_experiment_config(gram=False, preservation=True))
+    assert getattr(model, "gram_teacher", None) is not None
+    assert not has_lora(model.gram_teacher)
+
+
+@pytest.mark.ssl_unit
+def test_no_anchor_teacher_when_both_disabled():
+    """With neither gram nor preservation, no anchor teacher is built (memory unchanged)."""
+    config = _lora_experiment_config(gram=False, preservation=False)
+    model = DinoV3PlModel(config)
+    assert getattr(model, "gram_teacher", None) is None
+    assert not model._extra_losses()
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize(
+    "mutate,expected",
+    [
+        (lambda c: setattr(c.model.distill, "enable", True),
+         r"model\.lora\.enable is not supported together with model\.distill\.enable"),
+        (lambda c: setattr(c.model.gram, "teacher_source", "ema"),
+         r"model\.lora\.enable requires model\.gram\.teacher_source='pretrained'"),
+        (lambda c: setattr(c.train, "distributed_strategy", "fsdp"),
+         r"model\.lora\.enable is not supported with train\.distributed_strategy='fsdp'"),
+    ],
+    ids=["distill", "gram_ema", "fsdp"],
+)
+def test_lora_guardrails(mutate, expected):
+    """Each v1 incompatibility is rejected at build time with *its own* actionable message.
+
+    The messages are matched exactly, not by keyword: the distillation case in particular
+    would otherwise be satisfied by the inherited ``_build_model`` assert about a missing
+    ``pretrained_non_distill_pl_model_path``, which fires later and for a different reason.
+    """
+    config = _lora_experiment_config()
+    mutate(config)
+    with pytest.raises(AssertionError, match=expected):
+        DinoV3PlModel(config)
+
+
+@pytest.mark.ssl_unit
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda c: setattr(c.model.distill, "enable", True),
+        lambda c: setattr(c.model.gram, "teacher_source", "ema"),
+        lambda c: setattr(c.train, "distributed_strategy", "fsdp"),
+    ],
+    ids=["distill", "gram_ema", "fsdp"],
+)
+def test_guardrails_do_not_fire_when_lora_is_disabled(mutate):
+    """The guardrails constrain LoRA only — they must not restrict existing full-FT configs."""
+    config = _lora_experiment_config()
+    config.model.lora.enable = False
+    mutate(config)
+    # Any failure here must not come from _validate_lora_config.
+    try:
+        DinoV3PlModel(config)
+    except AssertionError as error:
+        assert "model.lora.enable" not in str(error), (
+            f"LoRA guardrail fired with lora disabled: {error}"
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Preservation loss behaviour (the G2.1 zero-start property, checked statically)
+# --------------------------------------------------------------------------------------
+
+@pytest.mark.ssl_unit
+def test_cls_preservation_loss_primitive_zero_for_identical_inputs():
+    """Both CLS preservation terms are exactly 0 when student == anchor (gate G2.1 at step 0)."""
+    from nvidia_tao_pytorch.ssl.dinov3.model.loss import ClsPreservationLoss
+
+    torch.manual_seed(0)
+    cls_tokens = torch.randn(BATCH_SIZE, 64)
+    cls_mse, cls_cosine = ClsPreservationLoss()(cls_tokens, cls_tokens.clone())
+
+    assert cls_mse.item() == pytest.approx(0.0, abs=1e-7)
+    assert cls_cosine.item() == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.ssl_unit
+def test_extra_losses_identity_through_the_real_path():
+    """Exercise ``_extra_losses`` itself, with the masking contract made explicit.
+
+    ``loss_fn(x, x) == 0`` only tests the primitive. Here the student and anchor are the same
+    weights by construction (LoRA is an identity at ``lora_B = 0``), and the terms are driven
+    through the production ``_extra_losses`` path. With masking and stochastic depth disabled
+    the identity is exact; with masking on, the terms are legitimately far from zero because
+    the student sees masked crops and the anchor does not. Both are asserted so a real
+    sync/remap regression cannot hide behind the masked value.
+    """
+    config = _lora_experiment_config()
+    config.model.backbone.drop_path_rate = 0.0
+    # fp32 identity check, so the xformers path (which hard-casts q/k/v to .half()) must be off.
+    config.train.use_custom_attention = False
+    model = DinoV3PlModel(config)
+    model.inject_lora_adapters()
+    model.eval()
+
+    size, patch = 64, model.patch_size
+    n_tokens = (size // patch) ** 2
+    torch.manual_seed(0)
+    crops = torch.randn(2, 3, size, size)
+
+    captured = {}
+    model._log_loss = lambda name, value: captured.__setitem__(name, float(value))
+
+    def run(masks):
+        with torch.no_grad():
+            out = model.student.backbone([crops, crops], masks=[masks, None])[0]
+        captured.clear()
+        model._extra_losses(student_backbone_global_output=out, global_crops=crops)
+        return dict(captured)
+
+    unmasked = run(torch.zeros(2, n_tokens, dtype=torch.bool))
+    assert unmasked["losses/cls_mse"] < 1e-5, unmasked
+    assert unmasked["losses/cls_cos"] < 1e-5, unmasked
+    assert unmasked["losses/gram_loss"] < 1e-5, unmasked
+
+    masked = run(torch.rand(2, n_tokens) < 0.3)
+    assert masked["losses/cls_cos"] > unmasked["losses/cls_cos"], (
+        "masking must move the CLS term; if it does not, the anchor is seeing the same "
+        "masked input and the documented contract is wrong"
+    )
+
+
+@pytest.mark.ssl_unit
+def test_cls_preservation_loss_grows_with_drift():
+    """Both terms increase monotonically as the student drifts away from the anchor."""
+    from nvidia_tao_pytorch.ssl.dinov3.model.loss import ClsPreservationLoss
+
+    torch.manual_seed(0)
+    anchor = torch.randn(BATCH_SIZE, 64)
+    noise = torch.randn_like(anchor)
+    loss_fn = ClsPreservationLoss()
+
+    previous = (-1.0, -1.0)
+    for scale in (0.1, 0.5, 1.0):
+        cls_mse, cls_cosine = loss_fn(anchor + scale * noise, anchor)
+        assert cls_mse.item() > previous[0]
+        assert cls_cosine.item() > previous[1]
+        previous = (cls_mse.item(), cls_cosine.item())


### PR DESCRIPTION
Lets `train.pretrained_model_path` accept a HuggingFace `DINOv3ViTModel` export, not just
the timm release.

### The bug this fixes is silent

The HF export holds the **same weights** as the timm one — verified bit-exact:
`cat([q_proj, k_proj, v_proj])` equals timm's fused `attn.qkv.weight` with **zero** difference,
as do `patch_embed` and `cls_token`. Only the serialization differs, in two ways the timm
remapper structurally could not express:

1. Different names throughout — `embeddings.*` / `layer.N.*` rather than bare / `blocks.N.*`.
2. Attention stored as **separate** `q_proj`/`k_proj`/`v_proj` rather than a fused `qkv`. That is
   a tensor transform, not a rename, so it needs its own pass (cf. `fuse_timm_swiglu_fc1`).

Under the timm rules alone exactly two keys coincided — `norm.weight` and `norm.bias` — so an HF
checkpoint loaded **2 of 211** tensors and training would proceed from an almost entirely random
backbone while `restore_pretrained_weights` still logged a successful load. Every downstream
retention number would have been meaningless, with nothing in the logs to say so.

### What changed

`is_hf_dinov3_state_dict` / `hf_to_tao` / `convert_hf_to_tao` in `checkpoint_remap.py`, detected
up front in `_remap_dinov3_state_dict`. Callers, specs and config are unchanged — pointing
`pretrained_model_path` at an HF directory now just works.

**On the bias question.** HF's config advertises `query_bias: true, value_bias: true`, while TAO
and timm build attention with `qkv_bias=False` — which looks like a genuine architecture
conflict. The shipped tensors are all zero (0 of 12 nonzero per projection), so dropping them is
lossless. `convert_hf_to_tao` **asserts** that rather than assuming it, and refuses to convert a
checkpoint whose q/k/v bias is nonzero instead of silently discarding weights.

### Test evidence

`pytest tests/ssl_unit_test/dinov3`: **107 passed, 4 skipped** (101 before this PR; 6 new tests
in `test_hf_checkpoint.py`). pylint 10.00/10, pydocstyle and flake8 clean.

End-to-end against the real checkpoint on the internal share, through the production load path:

| source | tensors | remapped | unmapped | coverage | residual missing |
|---|---|---|---|---|---|
| HF `dinov3-vitb16-pretrain-lvd1689m` | 211 | 163 | 0 | **163/163** | none |
| timm `vit_base_patch16_dinov3` | 162 | 162 | 0 | 162/163 | none |

- `max |HF − timm|` over shared tensors: **0.000e+00**
- forward feature parity: `x_norm_clstoken` cosine **0.99999994**, `x_norm_patchtokens` cosine
  **1.00000000**, max-abs **0.000e+00** on both

HF is in fact the *better* source: it ships `mask_token`, which timm omits and which TAO
otherwise initializes randomly for iBOT — the one key that shows up as missing on every timm load.

JIRA: TAO-2489.

**Stack:** `main` ← #84 ← #85 ← #86 ← this PR. Review and merge in order.