### PR TITLE
[TAO-2492] DINOv3: honour train.checkpoint_interval_unit='step'

### DIFF
--- a/nvidia_tao_pytorch/config/dinov3/default_config.py
+++ b/nvidia_tao_pytorch/config/dinov3/default_config.py
@@ -10,15 +10,16 @@ subclassing the nvdinov2 dataclasses. Only the genuinely new pieces are added he
 * a v3 ``map_params`` table with **patch-16** ViT entries (vit_s, vit_s_plus, vit_b, vit_l,
   vit_h_plus, vit_7b),
 * RoPE backbone fields (``rope_theta`` etc.) and patch-16 defaults,
-* a ``GramConfig`` for Gram anchoring (wired up in a later step), and
-* a disabled ``lora`` stub for forward-compatibility.
+* a ``GramConfig`` for Gram anchoring, and
+* ``LoRAConfig`` / ``PreservationConfig`` for parameter-efficient, geometry-preserving
+  continual pre-training.
 
 DINOv3 is Meta IP implemented inside TAO; the family/endpoint is named ``dinov3``
 (not ``nvdinov3``). ``nvdinov2`` stays frozen.
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from omegaconf import MISSING
 
@@ -27,6 +28,7 @@ from nvidia_tao_pytorch.config.utils.types import (
     INT_FIELD,
     FLOAT_FIELD,
     BOOL_FIELD,
+    LIST_FIELD,
     DATACLASS_FIELD,
 )
 from nvidia_tao_pytorch.config.nvdinov2.default_config import (
@@ -290,36 +292,113 @@ class GramConfig:
 
 @dataclass
 class LoRAConfig:
-    """Disabled LoRA stub for forward-compatibility (parameter-efficient SSL, Phase 2)."""
+    """LoRA config for parameter-efficient continual pre-training.
+
+    When enabled, the targeted projections of the student **and** EMA-teacher backbones are
+    replaced by key-preserving ``LoRALinear`` layers, the rest of the backbone is frozen, and
+    only ``lora_A``/``lora_B``, the DINO/iBOT heads and ``mask_token`` receive gradients. The
+    adapters are folded back into the base weights on ``convert``/``export``, so the shipped
+    artifact is a stock DINOv3 backbone. See ``docs/plans/dinov3_lora_design.md``.
+    """
 
     enable: bool = BOOL_FIELD(
         value=False,
         default_value=False,
-        description="Whether to apply LoRA adapters (disabled in v1)",
+        description="Whether to apply LoRA adapters to the backbone (parameter-efficient SSL)",
         display_name="enable lora",
-        popular="no"
+        popular="yes"
     )
     rank: int = INT_FIELD(
         value=8,
         default_value=8,
         valid_min=1,
         valid_max="inf",
-        description="LoRA rank",
+        description="LoRA rank (r). The low-rank update is dW = (alpha/r) * B @ A.",
         display_name="lora rank",
-        popular="no"
+        popular="yes"
     )
     alpha: float = FLOAT_FIELD(
         value=16.0,
         default_value=16.0,
-        description="LoRA scaling alpha",
+        description="LoRA scaling alpha; the applied scale is alpha / rank.",
         display_name="lora alpha",
+        popular="yes"
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        description="Dropout applied to the LoRA branch input only (the frozen base path is untouched).",
+        display_name="lora dropout",
         popular="no"
+    )
+    target_modules: List[str] = LIST_FIELD(
+        arrList=["qkv", "proj"],
+        default_value=["qkv", "proj"],
+        description=(
+            "Projections to adapt inside each targeted ViT block. 'qkv' and 'proj' are the "
+            "attention projections (the v1 default); 'fc1'/'fc2' additionally adapt the FFN. "
+            "SwiGLU backbones (ViT-S+/H+/7B) expose a fused fc1 and are deferred in v1."
+        ),
+        display_name="lora target modules",
+        popular="yes"
+    )
+    num_last_blocks: int = INT_FIELD(
+        value=0,
+        default_value=0,
+        valid_min=0,
+        valid_max="inf",
+        description="Adapt only the last N transformer blocks. 0 = all blocks.",
+        display_name="lora num last blocks",
+        popular="yes"
+    )
+
+
+@dataclass
+class PreservationConfig:
+    """CLS-token preservation against the frozen anchor teacher.
+
+    Gram anchoring (``GramConfig``) preserves *patch-token* geometry, which dense downstream
+    tasks depend on. This block preserves the *global* CLS embedding geometry that k-NN,
+    linear-probe and retrieval consumers depend on. It reuses the anchor (Gram) teacher's
+    forward pass -- the same output dict carries ``x_norm_clstoken`` alongside
+    ``x_norm_patchtokens`` -- so enabling it costs no extra teacher forward.
+    """
+
+    enable: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        description=(
+            "Whether to add CLS-token preservation losses against the frozen anchor teacher. "
+            "Recommended alongside LoRA for continual pre-training."
+        ),
+        display_name="enable preservation",
+        popular="yes"
+    )
+    cls_mse_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max="inf",
+        description="Weight of the CLS-token MSE preservation term (0 disables just this term).",
+        display_name="cls mse weight",
+        popular="yes"
+    )
+    cls_cosine_weight: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max="inf",
+        description="Weight of the CLS-token cosine preservation term (0 disables just this term).",
+        display_name="cls cosine weight",
+        popular="yes"
     )
 
 
 @dataclass
 class DINOv3ModelConfig:
-    """DINOv3 model config (reuses nvdinov2 distill/head, adds gram + lora)."""
+    """DINOv3 model config (reuses nvdinov2 distill/head, adds gram + lora + preservation)."""
 
     centering_method: str = STR_FIELD(
         value="sinkhorn",
@@ -351,7 +430,11 @@ class DINOv3ModelConfig:
     )
     lora: LoRAConfig = DATACLASS_FIELD(
         LoRAConfig(),
-        description="Disabled LoRA stub for forward-compatibility"
+        description="Configuration for LoRA parameter-efficient continual pre-training"
+    )
+    preservation: PreservationConfig = DATACLASS_FIELD(
+        PreservationConfig(),
+        description="Configuration for CLS-token preservation against the frozen anchor teacher"
     )
 
 

--- a/nvidia_tao_pytorch/ssl/dinov3/model/lora.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/lora.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Key-preserving LoRA for the DINOv3 SSL backbone.
+
+Parameter-efficient continual pre-training: instead of updating all 86 M ViT-B backbone
+weights, freeze them and learn a rank-``r`` update ``dW = (alpha/r) * B @ A`` per targeted
+projection. See ``docs/plans/dinov3_lora_design.md``.
+
+**Key-preserving by design.** :class:`LoRALinear` subclasses ``nn.Linear`` and adopts the
+wrapped layer's existing ``weight``/``bias`` *Parameter objects*, so the backbone state-dict
+keys are exactly the stock keys plus ``lora_A``/``lora_B``. This is deliberately *not* the
+CLIP branch's ``.original``-nesting wrapper, which renames every wrapped weight to
+``...qkv.original.weight``. Four DINOv3 subsystems depend on stable backbone key names:
+
+* ``checkpoint_remap.timm_to_tao`` / ``convert_ssl_to_timm`` (timm <-> TAO translation),
+* ``CustomModelCheckpoint`` (strips ``student.backbone.``/``teacher.backbone.`` prefixes),
+* ``DinoV3PlModel._sync_gram_teacher`` (loads the teacher backbone into the plain anchor teacher),
+* ``restore_pretrained_weights`` (non-strict load against reference keys).
+
+**EMA safety.** ``DinoV2PlModel.update_teacher`` zips ``student.parameters()`` with
+``teacher.parameters()`` element-wise, so LoRA must be injected into the student *and* the
+EMA teacher with identical structure. Injection order here is deterministic
+(``nn.Module`` registration order), so the two zips stay aligned. The frozen anchor (Gram)
+teacher deliberately gets **no** LoRA -- it anchors to the pretrained weights, which under
+LoRA are precisely the frozen base weights.
+"""
+
+import math
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from nvidia_tao_pytorch.core.tlt_logging import logging
+
+# Projections that may be targeted, mapped to their parent module inside a ViT block.
+# ``qkv``/``proj`` live on ``block.attn``; ``fc1``/``fc2`` on ``block.mlp``. SwiGLU
+# backbones (ViT-S+/H+/7B) expose a *fused* ``fc1`` -- targeting it is allowed but is
+# deferred in v1 (see the design doc's "Deferred" section).
+_TARGET_PARENT = {
+    "qkv": "attn",
+    "proj": "attn",
+    "fc1": "mlp",
+    "fc2": "mlp",
+}
+
+DEFAULT_TARGET_MODULES = ("qkv", "proj")
+
+
+class LoRALinear(nn.Linear):
+    """An ``nn.Linear`` that additionally learns a low-rank update, preserving its keys.
+
+    The frozen base path is the stock linear ``x @ W.T + b``; the LoRA path adds
+    ``(alpha/r) * dropout(x) @ A.T @ B.T``. ``lora_B`` is zero-initialized so a freshly
+    injected module is **exactly** the identity of the layer it replaced -- step-0 behavior
+    of the SSL run is unchanged (gate G1.1).
+
+    Attributes:
+        lora_A (nn.Parameter): Down-projection ``[rank, in_features]``, Kaiming-uniform init.
+        lora_B (nn.Parameter): Up-projection ``[out_features, rank]``, zero init.
+        scaling (float): ``alpha / rank``.
+        merged (bool): Whether :meth:`merge` has folded the delta into ``weight``.
+    """
+
+    def __init__(self, in_features, out_features, bias=True, rank=8, alpha=16.0,
+                 dropout=0.0, device=None, dtype=None):
+        """Build a LoRA-augmented linear layer.
+
+        Args:
+            in_features (int): Input dimension.
+            out_features (int): Output dimension.
+            bias (bool): Whether the base linear has a bias.
+            rank (int): LoRA rank ``r`` (must be >= 1).
+            alpha (float): LoRA scaling numerator; the applied scale is ``alpha / rank``.
+            dropout (float): Dropout applied to the LoRA branch input only.
+            device: Passed to ``nn.Linear``.
+            dtype: Passed to ``nn.Linear``.
+        """
+        super().__init__(in_features, out_features, bias=bias, device=device, dtype=dtype)
+        assert rank >= 1, f"LoRA rank must be >= 1, got {rank}"
+        self.rank = rank
+        self.alpha = float(alpha)
+        self.scaling = self.alpha / self.rank
+        self.merged = False
+
+        self.lora_A = nn.Parameter(torch.empty(rank, in_features, device=device, dtype=dtype))
+        self.lora_B = nn.Parameter(torch.zeros(out_features, rank, device=device, dtype=dtype))
+        self.lora_dropout = nn.Dropout(p=dropout) if dropout > 0.0 else nn.Identity()
+        # Persist alpha/rank as the single scalar that matters, so a checkpoint carries
+        # everything needed to fold the adapter in later. Without it ``convert``/``export``
+        # would have to re-derive the scale from whichever spec happened to be passed at
+        # merge time, and a mismatched alpha would silently produce a wrongly-scaled backbone.
+        self.register_buffer("lora_scaling", torch.tensor(self.scaling), persistent=True)
+        self.reset_lora_parameters()
+
+    def reset_lora_parameters(self):
+        """(Re)initialize the adapter: Kaiming-uniform ``A``, zero ``B`` (identity at init)."""
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        nn.init.zeros_(self.lora_B)
+
+    @classmethod
+    def from_linear(cls, linear, rank=8, alpha=16.0, dropout=0.0):
+        """Wrap an existing ``nn.Linear``, adopting its weight/bias Parameter objects.
+
+        The returned module shares (does not copy) ``linear.weight`` and ``linear.bias``, so
+        pretrained values carry over and the state-dict keys are unchanged.
+
+        Args:
+            linear (nn.Linear): The layer to augment.
+            rank (int): LoRA rank.
+            alpha (float): LoRA scaling numerator.
+            dropout (float): LoRA-branch dropout.
+
+        Returns:
+            LoRALinear: A layer numerically identical to ``linear`` at init.
+        """
+        module = cls(
+            linear.in_features,
+            linear.out_features,
+            bias=linear.bias is not None,
+            rank=rank,
+            alpha=alpha,
+            dropout=dropout,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+        )
+        # Adopt the original Parameter objects so pretrained weights and any existing
+        # optimizer/parameter identity are preserved.
+        module.weight = linear.weight
+        if linear.bias is not None:
+            module.bias = linear.bias
+        return module
+
+    def delta_weight(self):
+        """Return the low-rank weight update ``(alpha/r) * B @ A``, shaped like ``weight``.
+
+        Returns:
+            torch.Tensor: Delta shaped ``[out_features, in_features]``.
+        """
+        return (self.lora_B @ self.lora_A) * self.scaling
+
+    @torch.no_grad()
+    def merge(self):
+        """Fold the LoRA delta into the base ``weight`` and neutralize the adapter.
+
+        After merging, the module computes the stock linear function of the *adapted*
+        weights, so ``forward`` is unchanged (gate G1.2) while the adapter contributes
+        nothing further. Idempotent.
+        """
+        if self.merged:
+            return self
+        self.weight.data += self.delta_weight().to(self.weight.dtype)
+        # Zero the adapter so the merged module stays numerically equivalent whether or not
+        # a caller later re-runs the LoRA branch.
+        self.lora_B.data.zero_()
+        self.merged = True
+        return self
+
+    def forward(self, x):
+        """Apply the frozen base linear plus the low-rank update.
+
+        Args:
+            x (torch.Tensor): Input shaped ``[..., in_features]``.
+
+        Returns:
+            torch.Tensor: Output shaped ``[..., out_features]``.
+        """
+        out = F.linear(x, self.weight, self.bias)
+        if self.merged:
+            return out
+        lora_x = self.lora_dropout(x)
+        # Cast the adapter to the activation dtype so autocast/fp16 runs stay consistent.
+        lora_out = F.linear(F.linear(lora_x, self.lora_A.to(lora_x.dtype)),
+                            self.lora_B.to(lora_x.dtype))
+        return out + lora_out * self.scaling
+
+    def extra_repr(self):
+        """Include the LoRA hyper-parameters in the module repr."""
+        return f"{super().extra_repr()}, rank={self.rank}, alpha={self.alpha}, merged={self.merged}"
+
+
+def _resolve_target_blocks(backbone, num_last_blocks):
+    """Return the ``(index, block)`` pairs LoRA should be injected into.
+
+    Args:
+        backbone (nn.Module): A ``DinoV3VisionTransformer``.
+        num_last_blocks (int): Inject into the last ``n`` blocks; ``0`` means all blocks.
+
+    Returns:
+        list: ``[(block_index, block_module), ...]`` in ascending index order.
+    """
+    blocks = list(backbone.blocks)
+    if not num_last_blocks or num_last_blocks <= 0 or num_last_blocks >= len(blocks):
+        selected = list(range(len(blocks)))
+    else:
+        selected = list(range(len(blocks) - num_last_blocks, len(blocks)))
+    return [(i, blocks[i]) for i in selected]
+
+
+def inject_lora(backbone, rank=8, alpha=16.0, dropout=0.0,
+                target_modules=DEFAULT_TARGET_MODULES, num_last_blocks=0,
+                freeze_base=True, keep_mask_token_trainable=True):
+    """Replace targeted projections in a DINOv3 backbone with :class:`LoRALinear` in place.
+
+    Injection is idempotent per-module (an already-injected layer is skipped) and preserves
+    every base state-dict key. Call this for the student *and* the EMA teacher with the same
+    arguments so ``update_teacher``'s parameter zip stays aligned (gate G1.3).
+
+    Args:
+        backbone (nn.Module): A ``DinoV3VisionTransformer`` to modify in place.
+        rank (int): LoRA rank.
+        alpha (float): LoRA scaling numerator.
+        dropout (float): LoRA-branch dropout.
+        target_modules (Sequence[str]): Projection names to target, from
+            ``{'qkv', 'proj', 'fc1', 'fc2'}``.
+        num_last_blocks (int): Inject into the last ``n`` blocks; ``0`` = all blocks.
+        freeze_base (bool): Freeze every non-LoRA backbone parameter.
+        keep_mask_token_trainable (bool): Keep ``mask_token`` trainable. It is absent from the
+            (inference) DINOv3 checkpoint and drives iBOT masking, so freezing its random
+            init would break the SSL objective.
+
+    Returns:
+        list: Fully-qualified names of the injected modules (e.g. ``blocks.0.attn.qkv``).
+
+    Raises:
+        ValueError: If ``target_modules`` names an unknown projection.
+    """
+    unknown = [t for t in target_modules if t not in _TARGET_PARENT]
+    if unknown:
+        raise ValueError(
+            f"Unknown LoRA target_modules {unknown}; supported: {sorted(_TARGET_PARENT)}"
+        )
+
+    if freeze_base:
+        # Freeze the *base* only. Freezing indiscriminately would also switch off adapters
+        # added by an earlier call -- and since already-injected modules are skipped below,
+        # nothing would turn them back on. That made injection non-idempotent: a second call,
+        # or a staged ``qkv`` then ``proj`` injection, silently left the first batch of
+        # adapters frozen and training only the heads.
+        for name, param in backbone.named_parameters():
+            if not is_lora_key(name):
+                param.requires_grad = False
+
+    injected = []
+    for block_index, block in _resolve_target_blocks(backbone, num_last_blocks):
+        for target in target_modules:
+            parent = getattr(block, _TARGET_PARENT[target], None)
+            if parent is None:
+                continue
+            child = getattr(parent, target, None)
+            if child is None:
+                continue
+            if isinstance(child, LoRALinear):
+                continue  # already injected
+            if not isinstance(child, nn.Linear):
+                logging.warning(
+                    f"Skipping LoRA target blocks.{block_index}.{_TARGET_PARENT[target]}.{target}: "
+                    f"expected nn.Linear, found {type(child).__name__}."
+                )
+                continue
+            setattr(
+                parent, target,
+                LoRALinear.from_linear(child, rank=rank, alpha=alpha, dropout=dropout),
+            )
+            injected.append(f"blocks.{block_index}.{_TARGET_PARENT[target]}.{target}")
+
+    # Every adapter present must be trainable, including any added by an earlier call.
+    for name, param in backbone.named_parameters():
+        if is_lora_key(name):
+            param.requires_grad = True
+
+    if keep_mask_token_trainable and getattr(backbone, "mask_token", None) is not None:
+        backbone.mask_token.requires_grad = True
+
+    return injected
+
+
+def merge_lora(module):
+    """Merge every :class:`LoRALinear` under ``module`` into its base weights, in place.
+
+    After this, the module's forward is a stock DINOv3 forward of adapted weights, so a
+    traced/exported graph contains no LoRA ops (gate G3.4).
+
+    Args:
+        module (nn.Module): Any module containing LoRA layers (typically a backbone).
+
+    Returns:
+        int: Number of layers merged.
+    """
+    count = 0
+    for submodule in module.modules():
+        if isinstance(submodule, LoRALinear) and not submodule.merged:
+            submodule.merge()
+            count += 1
+    return count
+
+
+def has_lora(module):
+    """Whether ``module`` contains any :class:`LoRALinear` layer.
+
+    Args:
+        module (nn.Module): Module to inspect.
+
+    Returns:
+        bool: True if at least one LoRA layer is present.
+    """
+    return any(isinstance(m, LoRALinear) for m in module.modules())
+
+
+def is_lora_key(key):
+    """Whether a state-dict key belongs to a LoRA adapter.
+
+    Used to filter adapter keys out before loading a LoRA-injected teacher backbone into the
+    plain (un-injected) anchor teacher (gate G1.6), and before timm translation on convert.
+
+    Args:
+        key (str): State-dict key.
+
+    Returns:
+        bool: True for ``lora_A`` / ``lora_B`` keys.
+    """
+    return key.endswith("lora_A") or key.endswith("lora_B") or ".lora_" in key
+
+
+def strip_lora_keys(state_dict):
+    """Return a copy of ``state_dict`` with all LoRA adapter keys removed.
+
+    Args:
+        state_dict (Mapping): Source state dict.
+
+    Returns:
+        dict: State dict containing only the base (stock-topology) keys.
+    """
+    return {k: v for k, v in state_dict.items() if not is_lora_key(k)}
+
+
+def lora_parameter_report(model, name="model"):
+    """Summarize the trainable-parameter split of a (possibly LoRA-injected) model.
+
+    Args:
+        model (nn.Module): The model to report on (e.g. the student ``ModuleDict``).
+        name (str): Label used in the log line.
+
+    Returns:
+        dict: ``{'total', 'trainable', 'lora', 'trainable_fraction'}`` parameter counts.
+    """
+    total = trainable = lora = 0
+    for param_name, param in model.named_parameters():
+        n = param.numel()
+        total += n
+        if param.requires_grad:
+            trainable += n
+            if is_lora_key(param_name):
+                lora += n
+
+    stats = {
+        "total": total,
+        "trainable": trainable,
+        "lora": lora,
+        "trainable_fraction": (trainable / total) if total else 0.0,
+    }
+    logging.info(
+        f"[LoRA] {name}: {trainable:,} trainable / {total:,} total params "
+        f"({100.0 * stats['trainable_fraction']:.3f}%); of which LoRA adapters: {lora:,}."
+    )
+    return stats

--- a/nvidia_tao_pytorch/ssl/dinov3/model/loss.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/loss.py
@@ -3,11 +3,17 @@
 
 """DINOv3 losses.
 
-The only genuinely new DINOv3 loss term is :class:`GramLoss` (Gram anchoring). All other
-terms (DINO/iBOT/KoLeo) are inherited from ``nvdinov2`` and reused unchanged. The Gram
-term regularizes the student's patch-token feature *geometry* toward a frozen Gram teacher
-(initialized from the loaded DINOv3 weights), which DINOv3 uses to stabilize dense features
-during long pre-training. See the DINOv3 paper, "Gram anchoring".
+The genuinely new DINOv3 loss terms are the *preservation* terms; all others (DINO/iBOT/
+KoLeo) are inherited from ``nvdinov2`` and reused unchanged.
+
+* :class:`GramLoss` (Gram anchoring) regularizes the student's **patch-token** feature
+  geometry toward a frozen anchor teacher (initialized from the loaded DINOv3 weights),
+  which DINOv3 uses to stabilize dense features during long pre-training. See the DINOv3
+  paper, "Gram anchoring".
+* :class:`ClsPreservationLoss` regularizes the student's **CLS/global embedding** toward the
+  same frozen anchor teacher, guarding the geometry that k-NN / linear-probe / retrieval
+  consumers depend on. It reads the ``x_norm_clstoken`` of the anchor forward that Gram
+  anchoring already runs, so it costs no extra teacher pass.
 """
 
 from torch import nn
@@ -43,3 +49,37 @@ class GramLoss(nn.Module):
         gram_teacher = teacher @ teacher.transpose(-2, -1)
 
         return F.mse_loss(gram_student, gram_teacher)
+
+
+class ClsPreservationLoss(nn.Module):
+    """CLS-token preservation: MSE + cosine distance against a frozen anchor teacher.
+
+    Two complementary views of the same drift. The **MSE** term pins the absolute embedding
+    (magnitude included); the **cosine** term pins only the direction, which is what k-NN and
+    retrieval actually consume. Both are computed in fp32 for stability under autocast, and
+    both are exactly zero when the student equals the anchor -- the property gate G2.1 checks
+    at step 0 (LoRA is an identity at init, so the run must start at ~0 preservation loss).
+
+    The weights are applied by the caller, so a weight of 0 drops that term from the total
+    while its value is still logged as a drift diagnostic.
+    """
+
+    def forward(self, student_cls_token, teacher_cls_token):
+        """Compute the CLS MSE and cosine preservation terms.
+
+        Args:
+            student_cls_token (torch.Tensor): Student CLS embeddings ``[B, C]``.
+            teacher_cls_token (torch.Tensor): Frozen-anchor CLS embeddings ``[B, C]``
+                (already detached by the caller).
+
+        Returns:
+            Tuple[torch.Tensor, torch.Tensor]: ``(cls_mse, cls_cosine)`` scalars, where
+            ``cls_cosine`` is ``1 - mean cosine similarity`` (0 when perfectly aligned).
+        """
+        student = student_cls_token.float()
+        teacher = teacher_cls_token.float()
+
+        cls_mse = F.mse_loss(student, teacher)
+        cls_cosine = 1.0 - F.cosine_similarity(student, teacher, dim=-1).mean()
+
+        return cls_mse, cls_cosine

--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -37,12 +37,14 @@ from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer, Swi
 from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss, ClsPreservationLoss
 from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
     inject_lora,
+    is_lora_key,
     lora_parameter_report,
     strip_lora_keys,
 )
 from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
     TAO_ONLY_KEYS,
     fuse_timm_swiglu_fc1,
+    merge_lora_state_dict,
     timm_to_tao,
 )
 
@@ -265,7 +267,22 @@ class DinoV3PlModel(DinoV2PlModel):
         )
 
         injected = inject_lora(self.student.backbone, **kwargs)
-        inject_lora(self.teacher.backbone, **kwargs)
+        teacher_injected = inject_lora(self.teacher.backbone, **kwargs)
+
+        # An empty target set would otherwise freeze the whole backbone, mark LoRA as injected,
+        # and quietly train only the heads and mask_token -- a run that looks like LoRA and is
+        # not. Comparing the two lists also catches any future student/teacher topology
+        # divergence at injection time rather than as a silently misaligned EMA (gate G1.3).
+        assert injected, (
+            f"LoRA injected no modules (target_modules={target_modules}, "
+            f"num_last_blocks={lora_cfg.num_last_blocks}). model.lora.enable is set, so this "
+            "would train only the heads and mask_token while reporting a LoRA run."
+        )
+        assert injected == teacher_injected, (
+            "student and teacher received different LoRA injections "
+            f"(student={injected}, teacher={teacher_injected}); the EMA zip requires identical "
+            "parameter structure in both backbones."
+        )
 
         # Mirror the student's backbone (base + freshly initialized adapters) into the teacher
         # so both start identical; otherwise the teacher's random lora_A would make its EMA
@@ -652,6 +669,15 @@ class DinoV3PlModel(DinoV2PlModel):
             Tuple[dict, list]: ``(remapped, unmapped)`` where ``remapped`` is loadable into
             the backbone and ``unmapped`` lists source keys that had no shape-matching target.
         """
+        # Source carries adapters but the destination backbone cannot hold them (inference,
+        # export, or the start of a fresh run before injection): fold them into the base so the
+        # weights loaded are the *adapted* model. Without this the adapter keys are simply
+        # unmapped and the frozen base is silently used instead. When the destination is
+        # already LoRA-injected the adapters load normally and this does nothing.
+        if any(is_lora_key(k) for k in timm_state_dict) and \
+                not any(is_lora_key(k) for k in reference_state_dict):
+            timm_state_dict = merge_lora_state_dict(timm_state_dict)
+
         # Fuse split SwiGLU projections (fc1_g/fc1_x) into the fused fc1 for ViT-H+/7B before
         # the per-key shape match; plain-MLP (ViT-B/L) checkpoints are unaffected.
         timm_state_dict = fuse_timm_swiglu_fc1(timm_state_dict)
@@ -785,9 +811,31 @@ class DinoV3PlModel(DinoV2PlModel):
           preserving the global embedding geometry that k-NN/linear-probe/retrieval consume.
           Gated on ``preservation.enable``.
 
-        Both are logged unconditionally when active (even at weight 0) so they double as drift
-        diagnostics. Returns an empty list -- matching the DINOv2 base, hence unchanged
-        numerics -- when neither term is active.
+        **Input contract (important when reading these values).** The student tensors come from
+        the *masked* global crops the SSL step already computed, while the anchor runs on the
+        *unmasked* crops -- matching how DINOv3 applies Gram anchoring, and avoiding a second
+        student forward. Both terms are therefore a sum of two things: preservation of the
+        pretrained geometry (the intent) **and** sensitivity to iBOT masking. They are
+        consequently **not zero at step 0** even when the weights are identical, and they must
+        not be read as pure drift metrics.
+
+        Measured on ViT-B at init, where student and anchor weights are identical by
+        construction (LoRA is an identity at ``lora_B = 0``):
+
+        =====================  =========  =========  =========
+        condition              gram       cls_mse    cls_cos
+        =====================  =========  =========  =========
+        unmasked, eval          3.7e-09    4.3e-08    1.2e-07
+        30% masked, train       2.4e-02    5.8e-01    9.3e-01
+        =====================  =========  =========  =========
+
+        So the identity property is exact, but only observable with masking and stochastic
+        depth disabled -- which is how a sync/remap regression should be checked. During
+        training the value is dominated by masking and drop_path noise. For a true drift
+        measurement, run the anchor comparison periodically in eval mode on unmasked crops.
+
+        Both terms are logged unconditionally when active (even at weight 0). Returns an empty
+        list -- matching the DINOv2 base, hence unchanged numerics -- when neither is active.
 
         Args:
             **ctx: Context forwarded from ``DinoV2PlModel.student_forward`` (global/local
@@ -860,8 +908,11 @@ class DinoV3PlModel(DinoV2PlModel):
             )
             self._log_loss("losses/cls_mse", cls_mse)
             self._log_loss("losses/cls_cos", cls_cosine)
-            # Drift diagnostic (gate G4.5): 1 - cls_cos is the mean cosine to the anchor.
-            self._log_loss("diagnostics/cls_anchor_cosine", 1.0 - cls_cosine)
+            # Mean cosine between the (masked) student CLS and the (unmasked) anchor CLS.
+            # Deliberately *not* named as a drift metric: per the contract above it also
+            # carries the masking and drop_path response, so it is a trend/stability signal
+            # rather than a measure of how far the weights have moved.
+            self._log_loss("diagnostics/cls_anchor_cosine_masked", 1.0 - cls_cosine)
 
             if preservation_cfg.cls_mse_weight:
                 losses.append(preservation_cfg.cls_mse_weight * cls_mse)

--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -18,11 +18,13 @@ import os
 
 import torch
 import torch.nn as nn
+import torch.distributed as dist
 from torch.distributed.fsdp import (
     FullyShardedDataParallel as FSDP,
     FullStateDictConfig,
     StateDictType,
 )
+from pytorch_lightning.strategies.single_device import SingleDeviceStrategy
 from timm.layers import Mlp
 
 import nvidia_tao_pytorch.config.dinov3.default_config as v3_params
@@ -167,6 +169,56 @@ class DinoV3PlModel(DinoV2PlModel):
             "(FSDP flat-param wrapping of mostly-frozen modules needs use_orig_params=True). "
             "Use 'auto' or 'ddp' -- LoRA's optimizer state is tiny, so DDP fits comfortably."
         )
+
+    @torch.no_grad()
+    def update_teacher(self, momentum: float):
+        """EMA-update the teacher, skipping frozen base weights when LoRA is active.
+
+        The inherited implementation zips *all* student and teacher parameters. Under LoRA the
+        base weights are frozen and identical in both, so ``m*W + (1-m)*W`` is a no-op --
+        in exact arithmetic. In floating point it is not: the round-trip through
+        ``_foreach_mul_`` / ``_foreach_add_`` leaves a small residual every step, which
+        accumulates. Measured on the Stage-2 smoke, the teacher's base weights had drifted by
+        5.67e-05 (relative, worst tensor) after only 500 steps while the student's stayed
+        bit-exact -- so the "frozen" anchor was quietly moving, and an exported teacher backbone
+        would not have been exactly ``frozen base + merged delta``.
+
+        Restricting the EMA to parameters that are trainable in the student (the LoRA adapters,
+        the DINO/iBOT heads and ``mask_token``) makes the no-op exact, and is cheaper.
+
+        Falls back to the inherited behaviour whenever LoRA is not injected, so full-fine-tune
+        runs are numerically unchanged.
+
+        Args:
+            momentum (float): EMA momentum for the teacher update.
+        """
+        lora_cfg = getattr(self.model_config, "lora", None)
+        if not (lora_cfg is not None and lora_cfg.enable and self._lora_injected):
+            super().update_teacher(momentum)
+            return
+
+        # FSDP is asserted against in LoRA mode (_validate_lora_config), so the flat-param
+        # path the parent handles cannot arise here.
+        if not isinstance(self.trainer.strategy, SingleDeviceStrategy):
+            torch.cuda.synchronize()
+            dist.barrier()
+
+        teacher_params = []
+        student_params = []
+        for (name, student_param), (teacher_name, teacher_param) in zip(
+            self.student.named_parameters(), self.teacher.named_parameters()
+        ):
+            assert name == teacher_name, (
+                f"student/teacher parameter order diverged ({name} vs {teacher_name}); "
+                "LoRA must be injected into both backbones identically."
+            )
+            if not student_param.requires_grad:
+                continue  # frozen base weight: already identical in both, leave it untouched
+            teacher_params.append(teacher_param.data)
+            student_params.append(student_param.data)
+
+        torch._foreach_mul_(teacher_params, momentum)
+        torch._foreach_add_(teacher_params, student_params, alpha=1.0 - momentum)
 
     def inject_lora_adapters(self):
         """Inject LoRA into the student and EMA-teacher backbones. No-op unless enabled.

--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -32,7 +32,12 @@ from nvidia_tao_pytorch.ssl.nvdinov2.model.head import DinoHead
 from nvidia_tao_pytorch.ssl.nvdinov2.model.loss import DinoV2Loss
 from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
 from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer, SwiGLUFusedFull
-from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss
+from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss, ClsPreservationLoss
+from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
+    inject_lora,
+    lora_parameter_report,
+    strip_lora_keys,
+)
 from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
     TAO_ONLY_KEYS,
     fuse_timm_swiglu_fc1,
@@ -91,15 +96,144 @@ class DinoV3PlModel(DinoV2PlModel):
                 centering_method=centering_method,
             )
 
-        # Gram anchoring (DINOv3). The frozen Gram teacher is constructed in _build_model
-        # when enabled; sync it from the (now teacher==student) weights here so it is
-        # consistent even when no pretrained checkpoint is supplied. When a pretrained
-        # checkpoint is loaded, restore_pretrained_weights re-syncs it from the loaded
-        # teacher (the intended provenance for continual pre-training).
+        # Gram anchoring (DINOv3). The frozen anchor teacher is constructed in _build_model
+        # when Gram anchoring or CLS preservation is enabled; sync it from the (now
+        # teacher==student) weights here so it is consistent even when no pretrained
+        # checkpoint is supplied. When a pretrained checkpoint is loaded,
+        # restore_pretrained_weights re-syncs it from the loaded teacher (the intended
+        # provenance for continual pre-training).
         if getattr(self, 'gram_teacher', None) is not None:
             self._sync_gram_teacher()
         # Tracks the last global step the Gram teacher was EMA-refreshed (Phase 1 high-res).
         self._gram_last_refresh_step = -1
+
+        # LoRA is injected later (train.py, after restore_pretrained_weights and before
+        # trainer.fit). The guardrails were already checked at the top of _build_model.
+        self._lora_injected = False
+
+    @property
+    def preservation_config(self):
+        """CLS-preservation sub-config, tolerating specs built before it existed.
+
+        Returns:
+            PreservationConfig | None: The block, or ``None`` if absent from the spec.
+        """
+        return getattr(self.model_config, "preservation", None)
+
+    def _preservation_enabled(self):
+        """Whether CLS-token preservation is switched on.
+
+        Returns:
+            bool: True when the ``preservation`` block exists and is enabled.
+        """
+        preservation = self.preservation_config
+        return bool(preservation is not None and preservation.enable)
+
+    def _validate_lora_config(self):
+        """Assert the LoRA guardrails from the design doc (v1 scope).
+
+        LoRA is incompatible with three things in v1:
+
+        * ``distill.enable`` -- distillation adds a third ``student_ema`` ViT and loads a
+          teacher from a non-distill checkpoint; the injection lifecycle is unverified there.
+        * ``gram.teacher_source='ema'`` -- refreshing the anchor from the drifting EMA teacher
+          defeats the point of preservation (and would re-anchor to LoRA-adapted weights).
+        * FSDP -- flat-param wrapping of mostly-frozen modules needs ``use_orig_params=True``;
+          deferred. LoRA's optimizer state is tiny, so DDP is sufficient for ViT-B/L.
+
+        Raises:
+            AssertionError: If ``lora.enable`` is combined with any of the above.
+        """
+        lora_cfg = getattr(self.model_config, "lora", None)
+        if lora_cfg is None or not lora_cfg.enable:
+            return
+
+        assert not self.model_config.distill.enable, (
+            "model.lora.enable is not supported together with model.distill.enable in v1. "
+            "Distillation builds an extra student_ema backbone whose LoRA injection lifecycle "
+            "is not covered; run LoRA continual pre-training without distillation."
+        )
+        assert self.model_config.gram.teacher_source != "ema", (
+            "model.lora.enable requires model.gram.teacher_source='pretrained'. An EMA-refreshed "
+            "anchor tracks the drifting teacher, which defeats preservation -- the frozen "
+            "pretrained weights are the only exogenous anchor in the system."
+        )
+
+        strategy = os.environ.get(
+            "DINOV3_STRATEGY", getattr(self.train_config, "distributed_strategy", "auto")
+        ).lower()
+        assert strategy != "fsdp", (
+            "model.lora.enable is not supported with train.distributed_strategy='fsdp' in v1 "
+            "(FSDP flat-param wrapping of mostly-frozen modules needs use_orig_params=True). "
+            "Use 'auto' or 'ddp' -- LoRA's optimizer state is tiny, so DDP fits comfortably."
+        )
+
+    def inject_lora_adapters(self):
+        """Inject LoRA into the student and EMA-teacher backbones. No-op unless enabled.
+
+        Called from the train script **after** ``restore_pretrained_weights`` (so the loader
+        sees stock keys) and **before** ``trainer.fit`` (so Lightning resume checkpoints and
+        any distributed wrapping see the final module tree).
+
+        Three invariants are established here:
+
+        * **EMA zip alignment** -- the student and teacher are injected with identical
+          arguments, so ``update_teacher``'s element-wise ``zip`` of ``parameters()`` stays
+          aligned (gate G1.3).
+        * **Teacher starts equal to the student** -- ``lora_A`` is randomly initialized, so the
+          two backbones would otherwise disagree at step 0 and the teacher's adapter would not
+          be an EMA of the student's. The student's backbone state is mirrored into the
+          teacher after injection to guarantee equality (gate G2.4).
+        * **Teacher stays frozen** -- newly created adapter parameters default to
+          ``requires_grad=True``; the teacher's are switched off again (it is EMA-updated,
+          never gradient-updated).
+
+        The frozen anchor (Gram) teacher deliberately receives no LoRA: it anchors to the
+        pretrained weights, which under LoRA are exactly the frozen base weights.
+
+        Returns:
+            dict | None: The trainable-parameter report, or ``None`` when LoRA is disabled.
+        """
+        lora_cfg = getattr(self.model_config, "lora", None)
+        if lora_cfg is None or not lora_cfg.enable:
+            return None
+        if self._lora_injected:
+            return None
+
+        self._validate_lora_config()
+
+        target_modules = list(lora_cfg.target_modules)
+        kwargs = dict(
+            rank=lora_cfg.rank,
+            alpha=lora_cfg.alpha,
+            dropout=lora_cfg.dropout,
+            target_modules=target_modules,
+            num_last_blocks=lora_cfg.num_last_blocks,
+            freeze_base=True,
+        )
+
+        injected = inject_lora(self.student.backbone, **kwargs)
+        inject_lora(self.teacher.backbone, **kwargs)
+
+        # Mirror the student's backbone (base + freshly initialized adapters) into the teacher
+        # so both start identical; otherwise the teacher's random lora_A would make its EMA
+        # trajectory meaningless.
+        self.teacher.backbone.load_state_dict(self.student.backbone.state_dict())
+
+        # The teacher is EMA-updated, never gradient-updated.
+        for param in self.teacher.parameters():
+            param.requires_grad = False
+
+        self._lora_injected = True
+
+        if get_global_rank() == 0:
+            logging.info(
+                f"LoRA injected into {len(injected)} modules per backbone "
+                f"(rank={lora_cfg.rank}, alpha={lora_cfg.alpha}, dropout={lora_cfg.dropout}, "
+                f"targets={target_modules}, "
+                f"num_last_blocks={lora_cfg.num_last_blocks or 'all'})."
+            )
+        return lora_parameter_report(self.student, name="student (LoRA)")
 
     def _resolve_arch(self, backbone_type):
         """Look up DINOv3 ViT hyper-parameters for a backbone type from the v3 param map.
@@ -180,6 +314,11 @@ class DinoV3PlModel(DinoV2PlModel):
         attributes are re-derived here from the v3 param map so they are self-consistent
         regardless of the (nvdinov2) param map the parent ``__init__`` read.
         """
+        # Validate the LoRA guardrails before anything is constructed, so an unsupported
+        # combination reports *its own* reason rather than tripping a downstream assert
+        # (e.g. distillation's missing-checkpoint check) first.
+        self._validate_lora_config()
+
         # Re-derive dims from the v3 (patch-16) param map.
         student_arch = self._resolve_arch(self.student_backbone_type)
         teacher_arch = self._resolve_arch(self.teacher_backbone_type)
@@ -225,24 +364,33 @@ class DinoV3PlModel(DinoV2PlModel):
                 f"student_type is {self.student_backbone_type}."
             )
 
-        # Gram anchoring: build a separate frozen Gram teacher (a copy of the teacher
-        # backbone) when enabled. It is intentionally NOT placed inside self.teacher /
-        # self.student (so the parent's FSDP wrapping and CustomModelCheckpoint, which act on
-        # those ModuleDicts, leave it alone) and never receives gradients or EMA updates.
-        # Its weights are (re)synced from the teacher by _sync_gram_teacher.
-        if self.model_config.gram.enable:
+        # Preservation: build a separate frozen *anchor* teacher (a copy of the teacher
+        # backbone) when Gram anchoring OR CLS preservation is enabled -- both terms read the
+        # same single anchor forward, so one module serves both. It is intentionally NOT
+        # placed inside self.teacher / self.student (so the parent's FSDP wrapping and
+        # CustomModelCheckpoint, which act on those ModuleDicts, leave it alone) and never
+        # receives gradients, EMA updates, or LoRA adapters. Its weights are (re)synced from
+        # the teacher by _sync_gram_teacher.
+        if self.model_config.gram.enable or self._preservation_enabled():
             self.gram_teacher = self._make_backbone(teacher_arch)
             for param in self.gram_teacher.parameters():
                 param.requires_grad = False
             self.gram_teacher.eval()
             self.gram_loss = GramLoss()
+            self.cls_preservation_loss = ClsPreservationLoss()
 
     def _sync_gram_teacher(self):
-        """Copy the current teacher backbone weights into the frozen Gram teacher.
+        """Copy the current teacher backbone weights into the frozen anchor teacher.
 
         Called once at construction (teacher == student) and again after a pretrained
-        checkpoint is loaded (``restore_pretrained_weights``), so the Gram teacher always
+        checkpoint is loaded (``restore_pretrained_weights``), so the anchor teacher always
         anchors to the same DINOv3 weights the run starts from.
+
+        Under LoRA the teacher backbone carries ``lora_A``/``lora_B`` keys that the anchor
+        teacher (deliberately un-injected) does not have. They are filtered out before the
+        load; because the LoRA design is key-preserving, what remains is exactly the anchor
+        teacher's key set, and those base tensors are the frozen pretrained originals. So
+        this stays a strict load and the anchor provably cannot drift (gate G1.6).
         """
         teacher_backbone = self.teacher.backbone
         if isinstance(teacher_backbone, FSDP):
@@ -258,6 +406,16 @@ class DinoV3PlModel(DinoV2PlModel):
                 state_dict = teacher_backbone.state_dict()
         else:
             state_dict = teacher_backbone.state_dict()
+
+        # Drop LoRA adapter keys (absent from the un-injected anchor teacher); the remaining
+        # base keys must cover it exactly.
+        state_dict = strip_lora_keys(state_dict)
+        anchor_keys = set(self.gram_teacher.state_dict())
+        missing = anchor_keys - set(state_dict)
+        assert not missing, (
+            f"Anchor (Gram) teacher sync is missing base keys after LoRA filtering: {sorted(missing)}"
+        )
+
         self.gram_teacher.load_state_dict(state_dict)
         for param in self.gram_teacher.parameters():
             param.requires_grad = False
@@ -545,25 +703,55 @@ class DinoV3PlModel(DinoV2PlModel):
         if getattr(self, 'gram_teacher', None) is not None:
             self._sync_gram_teacher()
 
-    def _extra_losses(self, **ctx):
-        """Inject the DINOv3 Gram-anchoring loss into the inherited student_forward.
+    def _log_loss(self, name, value):
+        """Log a scalar loss/diagnostic under the run's standard step-logging settings.
 
-        Returns an empty list (matching the DINOv2 base) unless Gram anchoring is enabled,
-        the frozen Gram teacher has been built, and the global step has reached
-        ``gram.start_step``. Otherwise it runs the frozen Gram teacher on the global crops and
-        returns ``[w_gram * GramLoss(student_patches, teacher_patches)]``.
+        Args:
+            name (str): Scalar name (e.g. ``losses/cls_mse``).
+            value (torch.Tensor): Scalar value.
+        """
+        self.log(
+            name,
+            value,
+            on_step=True,
+            on_epoch=False,
+            prog_bar=False,
+            logger=True,
+            batch_size=self.batch_size,
+        )
+
+    def _extra_losses(self, **ctx):
+        """Inject the DINOv3 preservation losses into the inherited student_forward.
+
+        Two terms, both measured against the **same single forward** of the frozen anchor
+        teacher (its output dict carries ``x_norm_clstoken`` alongside ``x_norm_patchtokens``,
+        so CLS preservation costs no extra teacher pass):
+
+        * **Gram anchoring** -- MSE between student and anchor patch-cosine Gram matrices,
+          preserving the dense/patch geometry. Gated on ``gram.enable`` and ``gram.start_step``.
+        * **CLS preservation** -- MSE + cosine distance between student and anchor CLS tokens,
+          preserving the global embedding geometry that k-NN/linear-probe/retrieval consume.
+          Gated on ``preservation.enable``.
+
+        Both are logged unconditionally when active (even at weight 0) so they double as drift
+        diagnostics. Returns an empty list -- matching the DINOv2 base, hence unchanged
+        numerics -- when neither term is active.
 
         Args:
             **ctx: Context forwarded from ``DinoV2PlModel.student_forward`` (global/local
                 crops, masks, and the student global/local backbone outputs).
 
         Returns:
-            list: ``[weighted_gram_loss]`` when active, else ``[]``.
+            list: Weighted extra loss tensors to add to the total, possibly empty.
         """
         gram_cfg = self.model_config.gram
-        if not gram_cfg.enable or getattr(self, 'gram_teacher', None) is None:
+        preservation_cfg = self.preservation_config
+
+        gram_active = gram_cfg.enable and self.global_step >= gram_cfg.start_step
+        preservation_active = self._preservation_enabled()
+        if not (gram_active or preservation_active):
             return []
-        if self.global_step < gram_cfg.start_step:
+        if getattr(self, 'gram_teacher', None) is None:
             return []
 
         student_backbone_global_output = ctx.get("student_backbone_global_output")
@@ -574,21 +762,19 @@ class DinoV3PlModel(DinoV2PlModel):
         # Phase 1: EMA-refresh the Gram teacher on cadence (no-op when teacher_source != 'ema').
         self._maybe_refresh_gram_teacher()
 
-        student_patch_tokens = student_backbone_global_output["x_norm_patchtokens"]
-
         # Student patch grid (global crops are square; derive from the input + patch size).
         ps = self.patch_size
         student_grid = (global_crops.shape[-2] // ps, global_crops.shape[-1] // ps)
 
-        # Frozen Gram teacher: optionally at a higher resolution (gram.teacher_scale), no grad.
+        # Frozen anchor teacher: optionally at a higher resolution (gram.teacher_scale), no grad.
         # Force eval so stochastic depth / dropout stay off even though the parent is in train mode.
         scale = getattr(gram_cfg, "teacher_scale", 1.0) or 1.0
         self.gram_teacher.eval()
-        # The frozen Gram teacher lives outside the FSDP-wrapped student/teacher ModuleDicts, so
+        # The frozen anchor teacher lives outside the FSDP-wrapped student/teacher ModuleDicts, so
         # FSDP never places it on the sharding device — co-locate it with the input here (no-op
         # once moved / on single-GPU, where the module already follows the LightningModule). It
-        # then runs under the ambient autocast just like the student/teacher backbones (GramLoss
-        # upcasts to fp32 internally for the Gram product).
+        # then runs under the ambient autocast just like the student/teacher backbones (the
+        # preservation losses upcast to fp32 internally).
         if next(self.gram_teacher.parameters()).device != global_crops.device:
             self.gram_teacher.to(global_crops.device)
         with torch.no_grad():
@@ -598,19 +784,36 @@ class DinoV3PlModel(DinoV2PlModel):
                 )
             else:
                 teacher_input = global_crops
-            teacher_patch_tokens = self.gram_teacher(teacher_input)["x_norm_patchtokens"]
+            anchor_output = self.gram_teacher(teacher_input)
+            teacher_patch_tokens = anchor_output["x_norm_patchtokens"]
             # Pool the (higher-res) teacher grid back to the student grid before the Gram loss.
             teacher_grid = (teacher_input.shape[-2] // ps, teacher_input.shape[-1] // ps)
             teacher_patch_tokens = self._pool_tokens(teacher_patch_tokens, teacher_grid, student_grid)
 
-        gram_loss = self.gram_loss(student_patch_tokens, teacher_patch_tokens)
-        self.log(
-            "losses/gram_loss",
-            gram_loss,
-            on_step=True,
-            on_epoch=False,
-            prog_bar=False,
-            logger=True,
-            batch_size=self.batch_size,
-        )
-        return [gram_cfg.w_gram * gram_loss]
+        losses = []
+
+        if gram_active:
+            gram_loss = self.gram_loss(
+                student_backbone_global_output["x_norm_patchtokens"], teacher_patch_tokens
+            )
+            self._log_loss("losses/gram_loss", gram_loss)
+            losses.append(gram_cfg.w_gram * gram_loss)
+
+        if preservation_active:
+            # The CLS token is unaffected by the patch-grid pooling above, so it is read
+            # straight off the same anchor forward.
+            cls_mse, cls_cosine = self.cls_preservation_loss(
+                student_backbone_global_output["x_norm_clstoken"],
+                anchor_output["x_norm_clstoken"],
+            )
+            self._log_loss("losses/cls_mse", cls_mse)
+            self._log_loss("losses/cls_cos", cls_cosine)
+            # Drift diagnostic (gate G4.5): 1 - cls_cos is the mean cosine to the anchor.
+            self._log_loss("diagnostics/cls_anchor_cosine", 1.0 - cls_cosine)
+
+            if preservation_cfg.cls_mse_weight:
+                losses.append(preservation_cfg.cls_mse_weight * cls_mse)
+            if preservation_cfg.cls_cosine_weight:
+                losses.append(preservation_cfg.cls_cosine_weight * cls_cosine)
+
+        return losses

--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -32,7 +32,7 @@ from nvidia_tao_pytorch.core.distributed.comm import get_global_rank
 from nvidia_tao_pytorch.core.tlt_logging import logging
 from nvidia_tao_pytorch.ssl.nvdinov2.model.head import DinoHead
 from nvidia_tao_pytorch.ssl.nvdinov2.model.loss import DinoV2Loss
-from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import CustomModelCheckpoint, DinoV2PlModel
 from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer, SwiGLUFusedFull
 from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss, ClsPreservationLoss
 from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
@@ -920,3 +920,64 @@ class DinoV3PlModel(DinoV2PlModel):
                 losses.append(preservation_cfg.cls_cosine_weight * cls_cosine)
 
         return losses
+
+    def configure_callbacks(self):
+        """Configure callbacks, honouring ``train.checkpoint_interval_unit``.
+
+        The inherited NVDINOv2 implementation wires the periodic checkpoint with
+        ``every_n_epochs=checkpoint_interval`` only -- it never reads
+        ``checkpoint_interval_unit``, unlike the core base class, which supports both. That is
+        harmless for NVDINOv2's own recipes, but it makes step-unit checkpointing silently
+        no-op: a spec asking for "every 1000 steps" becomes "every 1000 *epochs*", i.e. never.
+
+        On cw-pdx that is not a cosmetic difference. GPU jobs are capped at 4 hours and one
+        Foxconn epoch is ~4,668 optimizer steps at ~7.7 s/step (~10 h), so an epoch boundary is
+        never reached inside a single allocation. With epoch-only checkpointing a requeued arm
+        would restart from step 0 every 4 hours and never finish -- and the periodic callback
+        is also what writes the full Lightning checkpoint that resume needs, so without it
+        there is nothing to resume *from*. Step-unit checkpointing is what makes the
+        requeue+resume loop viable at all.
+
+        The periodic callback is rebuilt through its public constructor rather than by poking
+        Lightning's private ``_every_n_*`` attributes, so this does not depend on Lightning
+        internals.
+
+        Returns:
+            Sequence[Callback]: the inherited callbacks, with the periodic checkpoint
+            re-wired to step cadence when the spec asks for it.
+        """
+        callbacks = super().configure_callbacks()
+
+        unit = self.experiment_spec["train"].get("checkpoint_interval_unit", "epoch")
+        if unit != "step":
+            return callbacks
+
+        interval = self.experiment_spec["train"]["checkpoint_interval"]
+        results_dir = self.experiment_spec["results_dir"]
+
+        rebuilt = []
+        for callback in callbacks:
+            # The periodic checkpoint is the unmonitored, keep-everything one. The best-metric
+            # callback (when enabled) is monitored, and TAOExceptionCheckpoint is a different
+            # class, so neither is touched.
+            if (isinstance(callback, CustomModelCheckpoint) and
+                    callback.monitor is None and
+                    callback.save_top_k == -1):
+                rebuilt.append(CustomModelCheckpoint(
+                    every_n_train_steps=interval,
+                    every_n_epochs=None,
+                    dirpath=results_dir,
+                    save_on_train_epoch_end=False,
+                    monitor=None,
+                    save_top_k=-1,
+                    save_last="link",
+                    filename="model_{epoch:03d}_{step:05d}",
+                    enable_version_counter=False,
+                ))
+                logging.info(
+                    "DINOv3: checkpointing every %d steps (checkpoint_interval_unit='step').",
+                    interval,
+                )
+            else:
+                rebuilt.append(callback)
+        return rebuilt

--- a/nvidia_tao_pytorch/ssl/dinov3/scripts/export.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/scripts/export.py
@@ -18,6 +18,7 @@ from nvidia_tao_pytorch.core.tlt_logging import logging
 from nvidia_tao_pytorch.config.dinov3.default_config import ExperimentConfig
 from nvidia_tao_pytorch.ssl.dinov3.model.pl_model import DinoV3PlModel
 from nvidia_tao_pytorch.ssl.dinov3.utils.checkpoint_remap import (
+    merge_lora_state_dict,
     TAO_ONLY_KEYS,
     extract_backbone_state_dict,
     is_full_checkpoint,
@@ -38,6 +39,11 @@ def _restore_export_checkpoint(model, model_path):
         model_path (str): Export checkpoint path.
     """
     state_dict = model._load_pretrained_state_dict(model_path)
+    # Export builds a plain backbone with no adapters, so any lora_* keys would simply be
+    # dropped as unexpected and the ONNX would be the frozen base model rather than the
+    # adapted one. Fold them in first; no-op for full-fine-tune checkpoints. This also keeps
+    # the traced graph free of LoRA ops, i.e. stock DINOv3 topology.
+    state_dict = merge_lora_state_dict(state_dict)
     if not is_full_checkpoint(state_dict):
         model.restore_pretrained_weights(preloaded_state_dict=state_dict)
         return

--- a/nvidia_tao_pytorch/ssl/dinov3/scripts/train.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/scripts/train.py
@@ -69,6 +69,12 @@ def run_experiment(experiment_config, key):
         model.pretrained_weights = pretrained_path
         model.restore_pretrained_weights()
 
+    # LoRA injection sits between the pretrained load and `fit` on purpose: after the load so
+    # `restore_pretrained_weights` only ever sees stock backbone keys, and before `fit` so
+    # Lightning resume checkpoints and any distributed wrapping see the final module tree.
+    # No-op unless model.lora.enable is set.
+    model.inject_lora_adapters()
+
     trainer = Trainer(**trainer_kwargs,
                       num_nodes=num_nodes,
                       strategy=_resolve_strategy(experiment_config),

--- a/nvidia_tao_pytorch/ssl/dinov3/utils/checkpoint_remap.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/utils/checkpoint_remap.py
@@ -161,6 +161,61 @@ def split_fused_swiglu_fc1(timm_state_dict, reference):
     return out
 
 
+def merge_lora_state_dict(state_dict):
+    """Fold any LoRA adapters in a backbone state dict into their base weights.
+
+    Turns ``{W, lora_A, lora_B, lora_scaling}`` into ``{W + scaling * (B @ A)}`` and drops the
+    adapter keys, so the result is a stock DINOv3 state dict that a plain ViT (or timm) loads
+    strictly. Without this step ``convert`` either fails validation on the unexpected ``lora_*``
+    keys or -- with ``validate=False`` -- writes them straight through, and ``export`` builds a
+    plain backbone that ignores them: in both cases the artifact is the *frozen base* model, not
+    the adapted one, with nothing in the output to say so.
+
+    The scale is read from the ``lora_scaling`` buffer stored alongside each adapter, so a
+    checkpoint carries everything needed to merge it and cannot be folded with the wrong alpha.
+
+    A state dict without adapters passes through untouched, so this is safe to call
+    unconditionally.
+
+    Args:
+        state_dict (Mapping): Backbone-level state dict in TAO naming, with or without adapters.
+
+    Returns:
+        dict: State dict with adapters folded in and all ``lora_*`` keys removed.
+
+    Raises:
+        ValueError: If an adapter is incomplete, or carries no scale to merge with.
+    """
+    merged = dict(state_dict)
+    prefixes = sorted({k[: -len("lora_A")] for k in state_dict if k.endswith("lora_A")})
+
+    for prefix in prefixes:
+        a_key, b_key = f"{prefix}lora_A", f"{prefix}lora_B"
+        scale_key, weight_key = f"{prefix}lora_scaling", f"{prefix}weight"
+        if b_key not in merged:
+            raise ValueError(f"{a_key} has no matching {b_key}; refusing to merge a partial adapter.")
+        if weight_key not in merged:
+            raise ValueError(f"{a_key} has no base weight at {weight_key}.")
+        if scale_key not in merged:
+            raise ValueError(
+                f"{a_key} has no {scale_key}; the alpha/rank scale is unknown, and guessing it "
+                "would silently produce a wrongly-scaled backbone."
+            )
+
+        lora_a = merged.pop(a_key)
+        lora_b = merged.pop(b_key)
+        scaling = merged.pop(scale_key).to(torch.float32).item()
+        base = merged[weight_key]
+        delta = (lora_b.to(torch.float32) @ lora_a.to(torch.float32)) * scaling
+        merged[weight_key] = (base.to(torch.float32) + delta).to(base.dtype).contiguous()
+
+    # Defensive: nothing lora-shaped may survive into a "stock" state dict.
+    leftover = [k for k in merged if ".lora_" in k or k.endswith(("lora_A", "lora_B"))]
+    if leftover:
+        raise ValueError(f"LoRA keys survived the merge: {sorted(leftover)}")
+    return merged
+
+
 def load_checkpoint_file(path):
     """Load a ``.safetensors`` / ``.pth`` / ``.ckpt`` checkpoint into a dict.
 
@@ -304,6 +359,9 @@ def convert_ssl_to_timm(src_path, dst_path, source="teacher", validate=True,
     """
     raw = load_checkpoint_file(src_path)
     backbone_state_dict = extract_backbone_state_dict(raw, source=source)
+    # Fold LoRA adapters into the base weights before translation, so the exported backbone is
+    # the *adapted* model in stock DINOv3 topology. No-op for full-fine-tune checkpoints.
+    backbone_state_dict = merge_lora_state_dict(backbone_state_dict)
     timm_state_dict = remap_tao_backbone_to_timm(backbone_state_dict)
     reference = timm.create_model(timm_model_name, pretrained=False).state_dict()
     timm_state_dict = split_fused_swiglu_fc1(timm_state_dict, reference)


### PR DESCRIPTION
**Superseded by #97**, which contains the same fix re-targeted at `main`.

Closed because this PR was stacked on the `feature/dinov3_lora_wiring` branch. The
review discussion here remains valid; please continue in #97.

### Summary

`train.checkpoint_interval_unit: "step"` was accepted by the schema but ignored by
the DINOv3 Lightning module, which always checkpointed on epoch boundaries.

On a time-capped scheduler that is not a cosmetic difference: whenever a single epoch
takes longer than the per-job wall-clock limit — routine for SSL pretraining on a large
corpus — an epoch boundary is never reached inside one allocation, so no periodic
checkpoint is ever written and a requeue restarts from scratch.

The fix adds `configure_callbacks` to rebuild the periodic `CustomModelCheckpoint` with
`every_n_train_steps` when the unit is `"step"`.
