### PR TITLE
[TAO-2511][Feature] Support frozen DINOv3 backbones in Visual ChangeNet

### DIFF
--- a/nvidia_tao_pytorch/config/visual_changenet/default_config.py
+++ b/nvidia_tao_pytorch/config/visual_changenet/default_config.py
@@ -131,7 +131,8 @@ class BackboneConfig:
         valid_options=(
             "fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,"
             "fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,"
-            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3"
+            "vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,"
+            "vit_huge_plus_dinov3,vit_7b_dinov3"
         )
     )
     feat_downsample: bool = BOOL_FIELD(

--- a/nvidia_tao_pytorch/cv/backbone_v2/dino_v3.py
+++ b/nvidia_tao_pytorch/cv/backbone_v2/dino_v3.py
@@ -16,6 +16,67 @@ import timm
 
 from nvidia_tao_pytorch.cv.backbone_v2 import BACKBONE_REGISTRY
 from nvidia_tao_pytorch.cv.backbone_v2.backbone_base import BackboneBase
+from nvidia_tao_pytorch.core.utils.ptm_utils import load_pretrained_weights
+
+
+_CONVERSION_HINT = (
+    "Run `dinov3 convert -e <dinov3_spec.yaml> "
+    "convert.checkpoint=<ssl_checkpoint> "
+    "convert.output_path=<converted_backbone.safetensors>` first."
+)
+
+
+def validate_dinov3_checkpoint(state_dict, allow_partial=False):
+    """Validate that a DINOv3 state dict uses the downstream timm layout.
+
+    TAO DINOv3 SSL checkpoints use a different key layout and must pass through
+    the existing `dinov3 convert` task before a downstream task consumes them.
+    Hugging Face `timm/*dinov3*` checkpoints and converted TAO checkpoints
+    both use the accepted timm layout.
+
+    Args:
+        state_dict (Mapping): DINOv3 state dict to validate.
+        allow_partial (bool): Permit incomplete timm-format state dicts while
+            retaining raw SSL checkpoint rejection.
+
+    Raises:
+        ValueError: If the state dict is empty, is a raw TAO SSL checkpoint, or
+            does not contain the required timm DINOv3 backbone keys.
+    """
+    if not state_dict and not allow_partial:
+        raise ValueError(f"DINOv3 checkpoint is empty. {_CONVERSION_HINT}")
+
+    keys = []
+    for key in state_dict:
+        normalized = key
+        for prefix in ("vit.", "inner."):
+            if normalized.startswith(prefix):
+                normalized = normalized[len(prefix):]
+                break
+        keys.append(normalized)
+
+    raw_ssl_markers = ("mask_token", "register_tokens")
+    is_raw_ssl = (
+        any(key in raw_ssl_markers for key in keys) or
+        any(key.endswith((".ls1.gamma", ".ls2.gamma")) for key in keys) or
+        any(key.startswith(("teacher.", "student.")) for key in keys)
+    )
+    if is_raw_ssl:
+        raise ValueError(
+            "Raw TAO DINOv3 SSL checkpoints are not accepted by downstream "
+            f"task backbones. {_CONVERSION_HINT}"
+        )
+
+    required_keys = ("cls_token", "patch_embed.proj.weight")
+    if allow_partial:
+        return
+    if not all(key in keys for key in required_keys) or not any(
+        key.startswith("blocks.0.") for key in keys
+    ):
+        raise ValueError(
+            "DINOv3 checkpoint is not a compatible timm-format backbone. "
+            f"{_CONVERSION_HINT}"
+        )
 
 
 class DINOV3Wrapper(BackboneBase):
@@ -117,6 +178,10 @@ class DINOV3Wrapper(BackboneBase):
             state_dict (dict): a dict containing parameters and persistent buffers.
             **kwargs: Additional arguments passed to `nn.Module.load_state_dict`.
         """
+        validate_dinov3_checkpoint(
+            state_dict,
+            allow_partial=not kwargs.get("strict", True),
+        )
         if state_dict and not any(k.startswith(("inner.", "head.")) for k in state_dict):
             state_dict = {f"inner.{k}": v for k, v in state_dict.items()}
         return super().load_state_dict(state_dict, **kwargs)
@@ -177,15 +242,35 @@ class DINOV3Wrapper(BackboneBase):
                 return self.head(cls_token)
 
 
-def _load_dino_v3(dino_v3_model: str, pretrained_backbone_path: Optional[str] = None):
+def create_dinov3_model(dino_v3_model: str, pretrained: bool = False, **kwargs):
+    """Create a timm DINOv3 model with actionable pretrained-weight errors."""
+    try:
+        return timm.create_model(dino_v3_model, pretrained=pretrained, **kwargs)
+    except Exception as exc:
+        if not pretrained:
+            raise
+        raise RuntimeError(
+            "Unable to load pretrained DINOv3 weights from timm/Hugging Face. "
+            "Ensure HF_TOKEN grants access to the gated model, or set "
+            "model.backbone.pretrained_backbone_path to a local converted TAO "
+            f"checkpoint. {_CONVERSION_HINT}"
+        ) from exc
+
+
+def _load_dino_v3(
+    dino_v3_model: str,
+    pretrained_backbone_path: Optional[str] = None,
+    pretrained: bool = False,
+):
     """Load the DINOv3 model.
 
     Args:
         dino_v3_model (str): The timm model name.
         pretrained_backbone_path (str, optional): Path to a local DINOv3
-            checkpoint file (``.pth``). When set, weights are loaded from disk
-            via timm's ``checkpoint_path`` mechanism; otherwise the pretrained
-            weights are downloaded from the timm/HF hub.
+            checkpoint file. When set, weights are validated and loaded from
+            disk; otherwise `pretrained` controls whether timm/HF weights are
+            downloaded.
+        pretrained (bool): Fetch timm/HF weights when no local path is set.
     """
     # option1: use torch.hub
     # model = torch.hub.load(
@@ -207,13 +292,15 @@ def _load_dino_v3(dino_v3_model: str, pretrained_backbone_path: Optional[str] = 
     # model = AutoModel.from_pretrained(ckpt_path)
     # option3: use timm
     if pretrained_backbone_path:
-        model = timm.create_model(
-            dino_v3_model,
-            pretrained=False,
-            checkpoint_path=pretrained_backbone_path,
+        state_dict = load_pretrained_weights(
+            pretrained_backbone_path,
+            weights_only=True,
         )
+        validate_dinov3_checkpoint(state_dict)
+        model = create_dinov3_model(dino_v3_model, pretrained=False)
+        model.load_state_dict(state_dict, strict=True)
     else:
-        model = timm.create_model(dino_v3_model, pretrained=False)
+        model = create_dinov3_model(dino_v3_model, pretrained=pretrained)
     return model
 
 
@@ -223,10 +310,11 @@ def dinov3_vit7b16(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_7b_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_7b_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model
 
@@ -237,10 +325,11 @@ def dinov3_vitl16(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_large_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_large_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model
 
@@ -251,10 +340,11 @@ def dinov3_vits16(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_small_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_small_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model
 
@@ -265,10 +355,11 @@ def dinov3_vits16plus(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_small_plus_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_small_plus_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model
 
@@ -279,10 +370,11 @@ def dinov3_vitb16(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_base_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_base_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model
 
@@ -293,9 +385,10 @@ def dinov3_vith16plus(pretrained_backbone_path: Optional[str] = None, **kwargs):
 
     Args:
         pretrained_backbone_path (str, optional): Local DINOv3 checkpoint path.
-            When ``None``, weights are downloaded from the timm/HF hub.
+            Pass ``pretrained=True`` to download timm/HF weights when unset.
         **kwargs: Forwarded to :class:`DINOV3Wrapper`.
     """
-    model = _load_dino_v3("vit_huge_plus_patch16_dinov3.lvd1689m", pretrained_backbone_path=pretrained_backbone_path)
+    pretrained = kwargs.pop("pretrained", False)
+    model = _load_dino_v3("vit_huge_plus_patch16_dinov3.lvd1689m", pretrained_backbone_path, pretrained)
     model = DINOV3Wrapper(model, **kwargs)
     return model

--- a/nvidia_tao_pytorch/cv/visual_changenet/backbone/dino_v3.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/backbone/dino_v3.py
@@ -17,18 +17,20 @@ RADIO summary tokens.
 import math
 from functools import partial
 
-import timm
 import torch
 import torch.nn.functional as F
 from torch import nn
 from torch.nn.init import normal_, trunc_normal_
 
 from nvidia_tao_pytorch.cv.backbone_v2.dino_v3 import (
+    create_dinov3_model,
+    dinov3_vit7b16,
     dinov3_vitb16,
     dinov3_vith16plus,
     dinov3_vitl16,
     dinov3_vits16,
     dinov3_vits16plus,
+    validate_dinov3_checkpoint,
 )
 from nvidia_tao_pytorch.cv.backbone_v2.nn.norm import FrozenBatchNorm2d
 from nvidia_tao_pytorch.cv.deformable_detr.model.ops.modules import MSDeformAttn
@@ -425,6 +427,10 @@ class DINOV3Adapter(nn.Module):
         The prefixing is all-or-nothing: it only triggers when no key is already an
         adapter/``vit.`` key.
         """
+        validate_dinov3_checkpoint(
+            state_dict,
+            allow_partial=not kwargs.get("strict", True),
+        )
         adapter_prefixes = (
             "vit.", "spm.", "interactions.", "level_embed", "up.",
             "norm1.", "norm2.", "norm3.", "norm4.",
@@ -438,14 +444,18 @@ class DINOV3Adapter(nn.Module):
 def _make_dinov3_adapter(
     timm_name, interaction_indexes,
     out_indices=None, resolution=224, activation_checkpoint=False,
-    use_summary_token=True, **kwargs
+    use_summary_token=True, pretrained=False, **kwargs
 ):
     """Build a DINOv3 ViT-Adapter with the family-shared adapter hyper-parameters.
 
-    The timm model is randomly initialized; weights come from
-    ``pretrained_backbone_path`` after construction.
+    Setting pretrained fetches timm's matching Hugging Face weights. Otherwise
+    Visual ChangeNet loads an explicit converted checkpoint after construction.
     """
-    dino_model = timm.create_model(timm_name, pretrained=False, img_size=resolution)
+    dino_model = create_dinov3_model(
+        timm_name,
+        pretrained=pretrained,
+        img_size=resolution,
+    )
     return DINOV3Adapter(
         dino_model,
         conv_inplane=56,
@@ -467,6 +477,7 @@ def _make_dinov3_adapter(
 _IDX_12 = [[0, 2], [3, 5], [6, 8], [9, 11]]
 _IDX_24 = [[0, 5], [6, 11], [12, 17], [18, 23]]
 _IDX_32 = [[0, 7], [8, 15], [16, 23], [24, 31]]
+_IDX_40 = [[0, 9], [10, 19], [20, 29], [30, 39]]
 
 
 def vit_small_dinov3(**kwargs):
@@ -494,6 +505,11 @@ def vit_huge_plus_dinov3(**kwargs):
     return _make_dinov3_adapter("vit_huge_plus_patch16_dinov3.lvd1689m", _IDX_32, **kwargs)
 
 
+def vit_7b_dinov3(**kwargs):
+    """DINOv3 ViT-7B/16 ViT-Adapter (embed_dim 4096, depth 40, SwiGLU)."""
+    return _make_dinov3_adapter("vit_7b_patch16_dinov3.lvd1689m", _IDX_40, **kwargs)
+
+
 # Arch 1 (euclidean difference): the DINOV3Wrapper cls-token backbone from backbone_v2,
 # mirroring vit_model_dict in dino_v2.py. With num_classes=0, forward(x) returns the
 # (B, embed_dim) cls token, matching ChangeNetClassify's fc_ip_dim = embed_dims[-1].
@@ -503,4 +519,5 @@ dinov3_model_dict = {
     "vit_base_dinov3": partial(dinov3_vitb16, num_classes=0),
     "vit_large_dinov3": partial(dinov3_vitl16, num_classes=0),
     "vit_huge_plus_dinov3": partial(dinov3_vith16plus, num_classes=0),
+    "vit_7b_dinov3": partial(dinov3_vit7b16, num_classes=0),
 }

--- a/nvidia_tao_pytorch/cv/visual_changenet/backbone/vit_adapter.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/backbone/vit_adapter.py
@@ -16,6 +16,7 @@ from nvidia_tao_pytorch.cv.backbone_v2.radio import RADIO
 from nvidia_tao_pytorch.cv.backbone_v2.vit import VisionTransformer
 from nvidia_tao_pytorch.cv.deformable_detr.model.ops.modules import MSDeformAttn
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.dino_v3 import (
+    vit_7b_dinov3,
     vit_base_dinov3,
     vit_huge_plus_dinov3,
     vit_large_dinov3,
@@ -780,6 +781,7 @@ def c_radio_v2_vit_base_patch16_224(
 
 
 vit_adapter_model_dict = {
+    "vit_7b_dinov3": vit_7b_dinov3,
     "vit_small_dinov3": vit_small_dinov3,
     "vit_small_plus_dinov3": vit_small_plus_dinov3,
     "vit_base_dinov3": vit_base_dinov3,

--- a/nvidia_tao_pytorch/cv/visual_changenet/classification/models/changenet.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/classification/models/changenet.py
@@ -27,6 +27,7 @@ from nvidia_tao_pytorch.core.tlt_logging import logger
 from nvidia_tao_pytorch.core.utils.pos_embed_interpolation import interpolate_patch_embed, interpolate_pos_embed
 from nvidia_tao_pytorch.core.utils.ptm_utils import load_pretrained_weights
 from nvidia_tao_pytorch.cv.backbone_v2.dino_v2 import DINOV2
+from nvidia_tao_pytorch.cv.backbone_v2.dino_v3 import validate_dinov3_checkpoint
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.dino_v2 import vit_model_dict
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.dino_v3 import dinov3_model_dict
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.fan import fan_model_dict
@@ -425,12 +426,20 @@ class ChangeNetClassify(nn.Module):
 
         freeze_at = None
         if freeze_backbone:
-            if pretrained_backbone_path is None:
+            if not pretrained_backbone_path and 'dinov3' not in self.model_name:
                 raise ValueError("You shouldn't freeze a model without specifying pretrained_backbone_path")
             freeze_at = "all"
 
+        use_dinov3_hf_weights = (
+            freeze_backbone and
+            not pretrained_backbone_path and
+            'dinov3' in self.model_name
+        )
+
         if get_global_rank() == 0:
             logger.info(f"Number of output classes: {output_nc}")
+            if use_dinov3_hf_weights:
+                logger.info("Loading frozen DINOv3 backbone weights from timm/Hugging Face")
 
         if 'fan' in self.model_name:
             assert (output_shape[0] % feature_strides[-1] == 0) and (output_shape[1] % feature_strides[-1] == 0), 'Input image size must be a multiple of 16'
@@ -465,11 +474,13 @@ class ChangeNetClassify(nn.Module):
                     resolution=output_shape[0],
                     activation_checkpoint=activation_checkpoint,
                     use_summary_token=use_summary_token,
+                    pretrained=use_dinov3_hf_weights,
                     freeze_at=freeze_at,
                     export=export,
                 )
             elif self.difference_module == 'euclidean':
                 self.backbone = dinov3_model_dict[self.model_name](
+                    pretrained=use_dinov3_hf_weights,
                     freeze_at=freeze_at,
                     export=export,
                 )
@@ -506,6 +517,8 @@ class ChangeNetClassify(nn.Module):
                     target_patch_size=14,
                     target_resolution=518,
                 )
+            if 'dinov3' in self.model_name:
+                validate_dinov3_checkpoint(state_dict)
             msg = self.backbone.load_state_dict(state_dict, strict=False)
             if get_global_rank() == 0:
                 logger.info(f"Loaded pretrained weights from {pretrained_backbone_path}")
@@ -639,6 +652,7 @@ def build_model(experiment_config,
                     "vit_base_dinov3": [768, 768, 768, 768],
                     "vit_large_dinov3": [1024, 1024, 1024, 1024],
                     "vit_huge_plus_dinov3": [1280, 1280, 1280, 1280],
+                    "vit_7b_dinov3": [4096, 4096, 4096, 4096],
                     "c_radio_p1_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],
                     "c_radio_p2_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],
                     "c_radio_p3_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],

--- a/nvidia_tao_pytorch/cv/visual_changenet/config/default_config.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/config/default_config.py
@@ -47,7 +47,7 @@ class ChangeNetHeadConfig:
 class BackboneConfig:
     """Configuration parameters for Backbone."""
 
-    type: str = STR_FIELD(value="fan_small_12_p4_hybrid", default_value="fan_small_12_p4_hybrid", description="Backbone architure", display_name="Backbone architectures", valid_options="fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3", automl_enabled="TRUE")
+    type: str = STR_FIELD(value="fan_small_12_p4_hybrid", default_value="fan_small_12_p4_hybrid", description="Backbone architure", display_name="Backbone architectures", valid_options="fan_tiny_8_p4_hybrid,fan_small_12_p4_hybrid,fan_base_16_p4_hybrid,fan_large_16_p4_hybrid,vit_large_nvdinov2,vit_small_dinov3,vit_small_plus_dinov3,vit_base_dinov3,vit_large_dinov3,vit_huge_plus_dinov3,vit_7b_dinov3", automl_enabled="TRUE")
     feat_downsample: bool = BOOL_FIELD(value=False, default_value=False, display_name="Feature downsample", description="Feature downsample")
     pretrained_backbone_path: Optional[str] = STR_FIELD(value=None, default_value="", description="Path to the pretrained model")
     freeze_backbone: bool = BOOL_FIELD(value=False, default_value=False, description="Flag to freeze backbone", automl_enabled="TRUE")

--- a/nvidia_tao_pytorch/cv/visual_changenet/segmentation/models/changenet.py
+++ b/nvidia_tao_pytorch/cv/visual_changenet/segmentation/models/changenet.py
@@ -26,6 +26,7 @@ from nvidia_tao_pytorch.core.distributed.comm import get_global_rank
 from nvidia_tao_pytorch.core.tlt_logging import logger
 from nvidia_tao_pytorch.core.utils.pos_embed_interpolation import interpolate_patch_embed, interpolate_pos_embed
 from nvidia_tao_pytorch.core.utils.ptm_utils import load_pretrained_weights
+from nvidia_tao_pytorch.cv.backbone_v2.dino_v3 import validate_dinov3_checkpoint
 from nvidia_tao_pytorch.cv.backbone_v2.nn.norm import FrozenBatchNorm2d
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.fan import fan_model_dict
 from nvidia_tao_pytorch.cv.visual_changenet.backbone.utils import ptm_adapter, visual_changenet_parser
@@ -318,11 +319,20 @@ class ChangeNetSegment(nn.Module):
 
         freeze_at = None
         if freeze_backbone:
-            if pretrained_backbone_path is None:
+            if not pretrained_backbone_path and 'dinov3' not in self.model_name:
                 raise ValueError("You shouldn't freeze a model without specifying pretrained_backbone_path")
             freeze_at = "all"
+
+        use_dinov3_hf_weights = (
+            freeze_backbone and
+            not pretrained_backbone_path and
+            'dinov3' in self.model_name
+        )
+
         if get_global_rank() == 0:
             logger.info(f"Number of output classes: {output_nc}")
+            if use_dinov3_hf_weights:
+                logger.info("Loading frozen DINOv3 backbone weights from timm/Hugging Face")
         assert img_size % feature_strides[-1] == 0, f"Input image size must be a multiple of {feature_strides[-1]}"
 
         if 'fan' in self.model_name:
@@ -349,6 +359,7 @@ class ChangeNetSegment(nn.Module):
                 resolution=img_size,
                 activation_checkpoint=activation_checkpoint,
                 use_summary_token=use_summary_token,
+                pretrained=use_dinov3_hf_weights,
                 freeze_at=freeze_at,
                 export=export,
             )
@@ -377,6 +388,8 @@ class ChangeNetSegment(nn.Module):
                     target_patch_size=16,
                     target_resolution=img_size,
                 )
+            if 'dinov3' in self.model_name:
+                validate_dinov3_checkpoint(pretrained_backbone_ckp)
             msg = self.backbone.load_state_dict(pretrained_backbone_ckp, strict=False)
             if get_global_rank() == 0:
                 logger.info(f"Loaded pretrained weights from {pretrained_backbone_path}")
@@ -446,6 +459,7 @@ def build_model(experiment_config,
                     "vit_base_dinov3": [768, 768, 768, 768],
                     "vit_large_dinov3": [1024, 1024, 1024, 1024],
                     "vit_huge_plus_dinov3": [1280, 1280, 1280, 1280],
+                    "vit_7b_dinov3": [4096, 4096, 4096, 4096],
                     "c_radio_p1_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],
                     "c_radio_p2_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],
                     "c_radio_p3_vit_huge_patch16_224_mlpnorm": [1280, 1280, 1280, 1280],

--- a/tests/cv_unit_test/visual_changenet/test_dinov3_backbone.py
+++ b/tests/cv_unit_test/visual_changenet/test_dinov3_backbone.py
@@ -1,0 +1,363 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for Visual ChangeNet DINOv3 backbone integration."""
+
+import pytest
+import torch
+from torch import nn
+
+from nvidia_tao_pytorch.cv.backbone_v2 import dino_v3 as backbone_v2_dino_v3
+from nvidia_tao_pytorch.cv.backbone_v2.dino_v3 import validate_dinov3_checkpoint
+from nvidia_tao_pytorch.cv.visual_changenet.backbone import dino_v3
+from nvidia_tao_pytorch.cv.visual_changenet.backbone.vit_adapter import vit_adapter_model_dict
+from nvidia_tao_pytorch.cv.visual_changenet.classification.models import (
+    changenet as classification_changenet,
+)
+from nvidia_tao_pytorch.cv.visual_changenet.segmentation.models import (
+    changenet as segmentation_changenet,
+)
+
+
+DINOV3_BACKBONES = {
+    "vit_small_dinov3",
+    "vit_small_plus_dinov3",
+    "vit_base_dinov3",
+    "vit_large_dinov3",
+    "vit_huge_plus_dinov3",
+    "vit_7b_dinov3",
+}
+
+
+def _valid_checkpoint():
+    return {
+        "cls_token": torch.empty(1),
+        "patch_embed.proj.weight": torch.empty(1),
+        "blocks.0.gamma_1": torch.empty(1),
+    }
+
+
+class _LogRecorder:
+    def __init__(self):
+        self.messages = []
+
+    def info(self, message):
+        self.messages.append(str(message))
+
+
+class _PatchEmbed(nn.Module):
+    patch_size = (16, 16)
+
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Conv2d(3, 12, kernel_size=16, stride=16)
+
+
+class _TinyDINOv3(nn.Module):
+    embed_dim = 12
+    num_prefix_tokens = 5
+    num_features = 12
+
+    def __init__(self):
+        super().__init__()
+        self.patch_embed = _PatchEmbed()
+        self.blocks = nn.ModuleList([nn.Linear(12, 12)])
+
+
+def test_all_dinov3_variants_are_registered():
+    """Both Visual ChangeNet difference paths expose all TAO DINOv3 variants."""
+    assert DINOV3_BACKBONES <= vit_adapter_model_dict.keys()
+    assert DINOV3_BACKBONES <= dino_v3.dinov3_model_dict.keys()
+
+
+def test_7b_factory_uses_40_block_partition(monkeypatch):
+    """The 7B factory selects the timm 7B model without constructing it in CI."""
+    monkeypatch.setattr(
+        dino_v3,
+        "_make_dinov3_adapter",
+        lambda timm_name, indexes, **kwargs: (timm_name, indexes, kwargs),
+    )
+    timm_name, indexes, kwargs = dino_v3.vit_7b_dinov3(resolution=224)
+    assert timm_name == "vit_7b_patch16_dinov3.lvd1689m"
+    assert indexes == [[0, 9], [10, 19], [20, 29], [30, 39]]
+    assert kwargs == {"resolution": 224}
+
+
+def test_dinov3_uses_validated_local_checkpoint_or_hf_fallback(monkeypatch):
+    """Local checkpoints are validated; an explicit flag enables the HF fallback."""
+    create_calls = []
+    load_calls = []
+    checkpoint = _valid_checkpoint()
+
+    class Model:
+        def load_state_dict(self, state_dict, strict=True):
+            load_calls.append((state_dict, strict))
+
+    sentinel = Model()
+
+    def create_model(name, **kwargs):
+        create_calls.append((name, kwargs))
+        return sentinel
+
+    def load_pretrained(path, **kwargs):
+        load_calls.append((path, kwargs))
+        return checkpoint
+
+    monkeypatch.setattr(backbone_v2_dino_v3.timm, "create_model", create_model)
+    monkeypatch.setattr(
+        backbone_v2_dino_v3,
+        "load_pretrained_weights",
+        load_pretrained,
+    )
+
+    assert backbone_v2_dino_v3._load_dino_v3("test_dinov3") is sentinel
+    assert create_calls[-1] == ("test_dinov3", {"pretrained": False})
+
+    assert backbone_v2_dino_v3._load_dino_v3(
+        "test_dinov3", pretrained=True
+    ) is sentinel
+    assert create_calls[-1] == ("test_dinov3", {"pretrained": True})
+
+    assert backbone_v2_dino_v3._load_dino_v3(
+        "test_dinov3",
+        pretrained_backbone_path="converted.safetensors",
+    ) is sentinel
+    assert create_calls[-1] == ("test_dinov3", {"pretrained": False})
+    assert load_calls == [
+        ("converted.safetensors", {"weights_only": True}),
+        (checkpoint, True),
+    ]
+
+
+def test_hf_failure_has_actionable_guidance(monkeypatch):
+    """Gated/offline Hugging Face errors explain both supported recovery paths."""
+
+    def fail_create_model(*args, **kwargs):
+        raise OSError("offline")
+
+    monkeypatch.setattr(backbone_v2_dino_v3.timm, "create_model", fail_create_model)
+    with pytest.raises(RuntimeError) as error:
+        backbone_v2_dino_v3._load_dino_v3("test_dinov3", pretrained=True)
+    assert "HF_TOKEN" in str(error.value)
+    assert "pretrained_backbone_path" in str(error.value)
+    assert "dinov3 convert" in str(error.value)
+
+
+def test_adapter_requests_hf_weights_when_pretrained(monkeypatch):
+    """The AOI learnable-difference adapter forwards the HF fallback to timm."""
+    calls = []
+    sentinel = object()
+
+    def create_model(name, **kwargs):
+        calls.append((name, kwargs))
+        return sentinel
+
+    monkeypatch.setattr(dino_v3, "create_dinov3_model", create_model)
+    monkeypatch.setattr(
+        dino_v3,
+        "DINOV3Adapter",
+        lambda model, **kwargs: (model, kwargs),
+    )
+
+    model, _ = dino_v3._make_dinov3_adapter(
+        "test_dinov3",
+        [[0, 0]],
+        resolution=224,
+        pretrained=True,
+    )
+    assert model is sentinel
+    assert calls == [("test_dinov3", {"pretrained": True, "img_size": 224})]
+
+
+@pytest.mark.parametrize("pretrained_path", [None, ""])
+def test_aoi_callers_freeze_dinov3_and_request_hf_fallback(monkeypatch, pretrained_path):
+    """Classification and segmentation forward null DINOv3 paths to timm."""
+    classify_logger = _LogRecorder()
+    monkeypatch.setattr(classification_changenet, "logger", classify_logger)
+    classify_calls = {}
+    classify_backbone = nn.Identity()
+
+    def classify_factory(**kwargs):
+        classify_calls.update(kwargs)
+        return classify_backbone
+
+    monkeypatch.setitem(
+        classification_changenet.vit_adapter_model_dict,
+        "vit_small_dinov3",
+        classify_factory,
+    )
+    monkeypatch.setattr(
+        classification_changenet,
+        "ChangeNetClassifyDecoder",
+        lambda **kwargs: nn.Identity(),
+    )
+    classify_model = classification_changenet.ChangeNetClassify(
+        model="vit_small_dinov3",
+        output_shape=[32, 32],
+        pretrained_backbone_path=pretrained_path,
+        freeze_backbone=True,
+    )
+    assert classify_model.backbone is classify_backbone
+    assert classify_calls["pretrained"] is True
+    assert classify_calls["freeze_at"] == "all"
+    assert any("timm/Hugging Face" in message for message in classify_logger.messages)
+
+    segment_calls = {}
+    segment_logger = _LogRecorder()
+    monkeypatch.setattr(segmentation_changenet, "logger", segment_logger)
+    segment_backbone = nn.Identity()
+
+    def segment_factory(**kwargs):
+        segment_calls.update(kwargs)
+        return segment_backbone
+
+    monkeypatch.setitem(
+        segmentation_changenet.vit_adapter_model_dict,
+        "vit_small_dinov3",
+        segment_factory,
+    )
+    monkeypatch.setattr(
+        segmentation_changenet,
+        "DecoderTransformer_v3",
+        lambda **kwargs: nn.Identity(),
+    )
+    segment_model = segmentation_changenet.ChangeNetSegment(
+        model="vit_small_dinov3",
+        img_size=32,
+        pretrained_backbone_path=pretrained_path,
+        freeze_backbone=True,
+    )
+    assert segment_model.backbone is segment_backbone
+    assert segment_calls["pretrained"] is True
+    assert segment_calls["freeze_at"] == "all"
+
+    assert any("timm/Hugging Face" in message for message in segment_logger.messages)
+
+
+def test_explicit_euclidean_checkpoint_uses_aoi_state_dict_loader(monkeypatch):
+    """The cls-token path keeps AOI parsing and wrapper validation."""
+    calls = {}
+    checkpoint = _valid_checkpoint()
+
+    class Backbone(nn.Module):
+        def load_state_dict(self, state_dict, strict=True):
+            calls["state_dict"] = state_dict
+            calls["strict"] = strict
+            return "loaded"
+
+    def factory(**kwargs):
+        calls.update(kwargs)
+        return Backbone()
+
+    monkeypatch.setitem(
+        classification_changenet.dinov3_model_dict,
+        "vit_small_dinov3",
+        factory,
+    )
+
+    def load_pretrained(path, **kwargs):
+        calls["loaded_path"] = path
+        return checkpoint
+
+    monkeypatch.setattr(
+        classification_changenet, "load_pretrained_weights", load_pretrained
+    )
+    classification_changenet.ChangeNetClassify(
+        model="vit_small_dinov3",
+        difference_module="euclidean",
+        output_shape=[32, 32],
+        pretrained_backbone_path="converted.safetensors",
+        freeze_backbone=True,
+    )
+    assert "pretrained_backbone_path" not in calls
+    assert calls["pretrained"] is False
+    assert calls["freeze_at"] == "all"
+    assert calls["loaded_path"] == "converted.safetensors"
+    assert calls["state_dict"] is checkpoint
+    assert calls["strict"] is False
+
+
+def test_existing_backbones_still_require_an_explicit_checkpoint_to_freeze():
+    """The null-checkpoint exception is limited to DINOv3 HF profiles."""
+    with pytest.raises(ValueError, match="without specifying"):
+        classification_changenet.ChangeNetClassify(
+            model="c_radio_v2_vit_base_patch16_224",
+            freeze_backbone=True,
+        )
+
+
+def test_frozen_dinov3_keeps_only_adapter_trainable():
+    """AOI frozen mode freezes the DINOv3 weights while training the task adapter."""
+    adapter = dino_v3.DINOV3Adapter(
+        _TinyDINOv3(),
+        conv_inplane=8,
+        interaction_indexes=[],
+        add_summary=False,
+        freeze_at="all",
+    )
+    assert all(not parameter.requires_grad for parameter in adapter.vit.parameters())
+    assert any(
+        parameter.requires_grad
+        for name, parameter in adapter.named_parameters()
+        if not name.startswith("vit.")
+    )
+
+
+def test_checkpoint_validation_accepts_timm_and_rejects_raw_ssl():
+    """Converted/HF timm keys pass while a raw TAO SSL layout gives conversion help."""
+    validate_dinov3_checkpoint(
+        {
+            "cls_token": torch.empty(1),
+            "patch_embed.proj.weight": torch.empty(1),
+            "blocks.0.gamma_1": torch.empty(1),
+        }
+    )
+    with pytest.raises(ValueError, match="dinov3 convert"):
+        validate_dinov3_checkpoint(
+            {
+                "cls_token": torch.empty(1),
+                "register_tokens": torch.empty(1),
+                "patch_embed.proj.weight": torch.empty(1),
+                "blocks.0.ls1.gamma": torch.empty(1),
+            }
+        )
+
+
+def test_wrapper_allows_partial_loads_but_still_rejects_raw_ssl():
+    """Intentional strict=False task loads are allowed without admitting raw SSL."""
+    wrapper = backbone_v2_dino_v3.DINOV3Wrapper(_TinyDINOv3())
+    result = wrapper.load_state_dict(
+        {"blocks.0.weight": torch.empty_like(wrapper.inner.blocks[0].weight)},
+        strict=False,
+    )
+    assert "inner.blocks.0.bias" in result.missing_keys
+    with pytest.raises(ValueError, match="dinov3 convert"):
+        wrapper.load_state_dict(
+            {"register_tokens": torch.empty(1)},
+            strict=False,
+        )
+
+
+def test_registry_local_path_rejects_raw_ssl_before_model_creation(monkeypatch):
+    """The explicit registry path validates weights before handing them to timm."""
+    raw_checkpoint = {
+        "cls_token": torch.empty(1),
+        "register_tokens": torch.empty(1),
+        "patch_embed.proj.weight": torch.empty(1),
+        "blocks.0.ls1.gamma": torch.empty(1),
+    }
+    monkeypatch.setattr(
+        backbone_v2_dino_v3,
+        "load_pretrained_weights",
+        lambda *args, **kwargs: raw_checkpoint,
+    )
+
+    def unexpected_create(*args, **kwargs):
+        raise AssertionError("model construction must follow validation")
+
+    monkeypatch.setattr(backbone_v2_dino_v3.timm, "create_model", unexpected_create)
+    with pytest.raises(ValueError, match="dinov3 convert"):
+        backbone_v2_dino_v3._load_dino_v3(
+            "test_dinov3",
+            pretrained_backbone_path="raw_ssl.safetensors",
+        )

--- a/tests/cv_unit_test/visual_changenet/test_legacy_config_backbone_parity.py
+++ b/tests/cv_unit_test/visual_changenet/test_legacy_config_backbone_parity.py
@@ -25,6 +25,7 @@ DINOV3_DOWNSTREAM_BACKBONES = [
     "vit_base_dinov3",
     "vit_large_dinov3",
     "vit_huge_plus_dinov3",
+    "vit_7b_dinov3",
 ]
 
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add frozen DINOv3 backbone support to the existing Visual ChangeNet classification and segmentation paths with minimal changes to the AOI architecture.

- Supports ViT-S, S+, B, L, H+, and 7B through the existing ViT adapter and task heads.
- Keeps the DINOv3 ViT frozen while the AOI adapter and classification or segmentation head remain trainable.
- Gives an explicit converted TAO checkpoint precedence; when no checkpoint is configured, frozen DINOv3 loads matching timm/Hugging Face weights.
- Routes explicit euclidean checkpoints through the existing AOI parser and state-dict loader, including actionable rejection of raw SSL checkpoints.
- Adds the 7B channel map and 40-block adapter partition.
- Preserves existing C-RADIO behavior and defaults.

Example:

```yaml
model:
  backbone:
    type: vit_large_dinov3
    pretrained_backbone_path: /data/pretrained_models/dinov3_vit_l_backbone.safetensors
    freeze_backbone: true
```

Set `pretrained_backbone_path: null` to use the matching timm/Hugging Face pretrained weights.

### Why are the changes needed?

DEFT AOI needs to reuse DINOv3 SSL features without updating the backbone. This keeps the established Visual ChangeNet task-level fine-tuning design while allowing either a converted TAO DINOv3 checkpoint or the compatible public timm/Hugging Face weights.

### Related issues

JIRA: TAO-2511.

Companion changes are in tao-core and tao-skill-bank on the same TAO-2511 branch.

### Does this PR introduce _any_ user-facing change?

Yes. Visual ChangeNet users can select all six DINOv3 variants and freeze the ViT. Existing backbone types, C-RADIO behavior, and defaults are unchanged.

### How was this patch tested?

- Required TAO image, focused DINOv3 and config parity suite: **12 passed**.
- Required TAO image, broader Visual ChangeNet model suite: **66 passed, 2 skipped**.
- Exact PR-range CI hooks: license, pylint, pydocstyle, and flake8 passed.
- Confirmed timm 1.0.26 exposes all six configured model names.
- Independent architecture, correctness, and MR-readiness panel: **3/3 READY**.
- `git diff --check` and no-Markdown checks passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex

### Release note

```release-note
Visual ChangeNet classification and segmentation now support frozen DINOv3 ViT-S, S+, B, L, H+, and 7B backbones using converted TAO checkpoints or compatible timm/Hugging Face pretrained weights.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`)
- [x] I have read the contributing guidelines
- [x] The code follows the project style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All applicable tests pass locally
- [x] I updated inline configuration documentation and docstrings
- [ ] A version or changelog update is not required for this patch
- [x] Optional imports remain guarded
- [x] No secrets, credentials, proprietary data, or customer data are included
- [x] I understand the contribution is licensed under the repository license

### Notes for reviewers

No Markdown files are changed. Start with `cv/backbone_v2/dino_v3.py`, then the two Visual ChangeNet model constructors and the focused regression test. The change deliberately reuses existing AOI adapters and heads instead of introducing a parallel task package.