### PR TITLE
[TAO-2492] Honour attn_bias in the SDPA fallback attention (silently corrupts SSL training on Hopper/Blackwell; also ~8x faster)

### DIFF
--- a/nvidia_tao_pytorch/ssl/dinov3/model/layers/attention.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/layers/attention.py
@@ -58,7 +58,12 @@ class RoPEMemoryEfficientAttention(MemoryEfficientAttention):
             # the shared SDPA-based fallback (base MemoryEfficientAttention._fallback_attention) so
             # both SSL families get the same numerically-safe, fused compute; RoPE has already been
             # applied to q/k above. See bug 6460915.
-            x = self._fallback_attention(q, k, v)
+            #
+            # attn_bias is forwarded: the block concatenates its crop list into one sequence,
+            # so without the block-diagonal mask every image attends to every other image in
+            # the batch. That silently destroyed features on Hopper, where this path is the
+            # only one available (bug 6459926 forces xformers off).
+            x = self._fallback_attention(q, k, v, attn_bias)
 
         x = x.reshape(B, N, C)
         x = self.proj(x)

--- a/nvidia_tao_pytorch/ssl/dinov3/model/layers/attention.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/layers/attention.py
@@ -61,8 +61,8 @@ class RoPEMemoryEfficientAttention(MemoryEfficientAttention):
             #
             # attn_bias is forwarded: the block concatenates its crop list into one sequence,
             # so without the block-diagonal mask every image attends to every other image in
-            # the batch. That silently destroyed features on Hopper, where this path is the
-            # only one available (bug 6459926 forces xformers off).
+            # the batch, which silently corrupts features wherever this fallback is the only
+            # available path.
             x = self._fallback_attention(q, k, v, attn_bias)
 
         x = x.reshape(B, N, C)

--- a/nvidia_tao_pytorch/ssl/nvdinov2/model/layers/attention.py
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/model/layers/attention.py
@@ -27,20 +27,17 @@ class MemoryEfficientAttention(Attention):
         GPUs, where ``use_custom_attention`` is force-disabled for both SSL families. See bug 6460915
         and the MR !652 SDPA review.
 
-        ``attn_bias`` MUST be honoured. The SSL blocks concatenate their crop list into a
-        single sequence via ``get_attn_bias_and_cat`` -- so one "batch" row holds every image's
-        tokens end to end -- and the block-diagonal mask is the only thing preventing image i's
+        ``attn_bias`` must be honoured. The SSL blocks concatenate their crop list into a
+        single sequence via ``get_attn_bias_and_cat``, so one "batch" row holds every image's
+        tokens end to end, and the block-diagonal mask is the only thing preventing image i's
         tokens from attending to image j's. Dropping it silently blends the whole batch
-        together: features stop depending on their own image, and the damage grows with batch
-        size. Measured on H100 against timm's reference DINOv3, CLS cosine was 1.000 at batch 1,
-        0.658 at 2, 0.368 at 4 and 0.193 at 8, and ImageNet k-NN fell from 82.4% to 4.0%.
+        together, and the damage grows with batch size.
 
-        The mask is applied by **splitting**, not by materializing. A dense
+        The mask is applied by splitting rather than materializing. A dense
         ``[1, heads, N, N]`` mask is what xformers' structured ``BlockDiagonalMask`` exists to
-        avoid: for DINOv3 training (2 global crops at 512 px + 4 local at 112 px, batch 16) the
-        concatenated sequence is ~36k tokens, so the dense mask would be ~55 GiB and OOMs
-        immediately. Splitting back into per-crop blocks and attending within each is
-        mathematically identical and allocates nothing extra.
+        avoid -- at DINOv3's multi-crop sequence lengths it is tens of GiB and OOMs. Splitting
+        back into per-crop blocks and attending within each is mathematically identical, and
+        allocates nothing extra.
 
         Args:
             q, k, v: ``[B, N, num_heads, head_dim]`` (xformers layout, post QK-norm).

--- a/nvidia_tao_pytorch/ssl/nvdinov2/model/layers/attention.py
+++ b/nvidia_tao_pytorch/ssl/nvdinov2/model/layers/attention.py
@@ -12,7 +12,7 @@ from xformers.ops import memory_efficient_attention
 class MemoryEfficientAttention(Attention):
     """Memory Efficient Attention"""
 
-    def _fallback_attention(self, q, k, v):
+    def _fallback_attention(self, q, k, v, attn_bias=None):
         """Non-xformers fallback attention via PyTorch SDPA, computed in fp32.
 
         ``q``, ``k``, ``v`` are ``[B, N, num_heads, head_dim]`` (xformers layout, post QK-norm);
@@ -27,20 +27,51 @@ class MemoryEfficientAttention(Attention):
         GPUs, where ``use_custom_attention`` is force-disabled for both SSL families. See bug 6460915
         and the MR !652 SDPA review.
 
+        ``attn_bias`` MUST be honoured. The SSL blocks concatenate their crop list into a
+        single sequence via ``get_attn_bias_and_cat`` -- so one "batch" row holds every image's
+        tokens end to end -- and the block-diagonal mask is the only thing preventing image i's
+        tokens from attending to image j's. Dropping it silently blends the whole batch
+        together: features stop depending on their own image, and the damage grows with batch
+        size. Measured on H100 against timm's reference DINOv3, CLS cosine was 1.000 at batch 1,
+        0.658 at 2, 0.368 at 4 and 0.193 at 8, and ImageNet k-NN fell from 82.4% to 4.0%.
+
+        The mask is applied by **splitting**, not by materializing. A dense
+        ``[1, heads, N, N]`` mask is what xformers' structured ``BlockDiagonalMask`` exists to
+        avoid: for DINOv3 training (2 global crops at 512 px + 4 local at 112 px, batch 16) the
+        concatenated sequence is ~36k tokens, so the dense mask would be ~55 GiB and OOMs
+        immediately. Splitting back into per-crop blocks and attending within each is
+        mathematically identical and allocates nothing extra.
+
+        Args:
+            q, k, v: ``[B, N, num_heads, head_dim]`` (xformers layout, post QK-norm).
+            attn_bias: xformers block-diagonal mask, or ``None``.
+
         Returns:
             torch.Tensor: ``[B, N, num_heads, head_dim]`` (same layout as the input).
         """
         out_dtype = q.dtype
-        q = q.transpose(1, 2)
-        k = k.transpose(1, 2)
-        v = v.transpose(1, 2)
-        with torch.autocast("cuda", enabled=False):
-            x = F.scaled_dot_product_attention(
-                q.float(), k.float(), v.float(),
-                dropout_p=self.attn_drop.p if self.training else 0.0,
-                scale=self.scale,
-            )
-        return x.to(out_dtype).transpose(1, 2)
+
+        def _sdpa(qh, kh, vh):
+            """SDPA on ``[b, n, heads, dim]`` inputs, returning the same layout."""
+            with torch.autocast("cuda", enabled=False):
+                x = F.scaled_dot_product_attention(
+                    qh.transpose(1, 2).float(),
+                    kh.transpose(1, 2).float(),
+                    vh.transpose(1, 2).float(),
+                    dropout_p=self.attn_drop.p if self.training else 0.0,
+                    scale=self.scale,
+                )
+            return x.to(out_dtype).transpose(1, 2)
+
+        if attn_bias is None:
+            return _sdpa(q, k, v)
+
+        # Block-diagonal attention == independent attention per crop block. `split` is the
+        # documented inverse of `get_attn_bias_and_cat`, so this restores the per-crop batches,
+        # attends within each, and re-concatenates in the original order.
+        qs, ks, vs = attn_bias.split(q), attn_bias.split(k), attn_bias.split(v)
+        outs = [_sdpa(qi, ki, vi) for qi, ki, vi in zip(qs, ks, vs)]
+        return torch.cat([o.reshape(1, -1, o.shape[2], o.shape[3]) for o in outs], dim=1)
 
     def forward(self, x, attn_bias=None, use_custom_attention=True):
         """Apply memory_efficient_attention in xformers
@@ -68,7 +99,7 @@ class MemoryEfficientAttention(Attention):
                     p=self.attn_drop.p,
                 )
         else:
-            x = self._fallback_attention(q, k, v)
+            x = self._fallback_attention(q, k, v, attn_bias)
 
         x = x.reshape(B, N, C)
         x = self.proj(x)


### PR DESCRIPTION
## Summary

`MemoryEfficientAttention.forward` passes `attn_bias` to xformers, but called
`self._fallback_attention(q, k, v)` **without it**.

The SSL blocks concatenate their crop list into a single sequence via
`get_attn_bias_and_cat`, so one "batch" row holds every image's tokens end to end. The
block-diagonal `attn_bias` is the **only** thing preventing image *i*'s tokens from attending
to image *j*'s. Dropping it blends the entire batch together.

## Impact

**Every DINOv3 and NVDINOv2 training run with batch > 1 on any GPU where xformers custom
attention is unavailable** — Hopper (where it is force-disabled) and Blackwell (by design).

A100 is unaffected because it takes the xformers path, which carries the mask. That is why this
survived workstation testing: the gates all pass there.

The failure is silent. Losses look normal, checkpoints look normal, and every *relative* check
(identity, frozen-base bit-identity, key preservation, drift-vs-anchor) still passes, because
both sides of each comparison come from the same corrupted model.

## Evidence — correctness

Measured on H100 against timm's `vit_base_patch16_dinov3.lvd1689m` loaded from the **same
checkpoint** (weights bit-identical: 162/162 tensors, `allclose` atol 1e-6):

| batch | CLS cosine vs timm — before | after |
|---|---|---|
| 1 | 1.000000 | 1.000000 |
| 2 | 0.657706 | **1.000000** |
| 4 | 0.368179 | **1.000000** |
| 8 | 0.192695 | **1.000000** |

| | before | after | reference |
|---|---|---|---|
| ImageNet k-NN top-1 (100 classes, k=20, chance 1.00%) | **4.00%** | **82.40%** | timm 82.40% |
| Feature pairwise cosine at batch 8 | 0.8750 | 0.0568 | timm 0.0568 |

The clearest symptom: at batch 8 the pairwise feature cosine was **0.875 for both random noise
and real photographs** — identical. The features had stopped depending on their input.

## Evidence — throughput (the fix is also much faster)

Attention over the concatenated sequence is O(N²) in the total token count rather than per
crop, so the missing mask was not only destroying features, it was paying a large multiple of
the necessary compute to do it:

| 8×H100, multi-crop SSL config | rate |
|---|---|
| before | 0.13 it/s |
| after | **0.99–1.18 it/s** |

On a full-scale training run the end-to-end speedup measured ~18×.

## Implementation note — split, don't materialize

The obvious fix, materializing `attn_bias` into a dense additive `[1, heads, N, N]` mask, is
correct but **unusable in training**: it allocates precisely what xformers' structured
`BlockDiagonalMask` exists to avoid. At DINOv3 multi-crop sequence lengths that mask is tens of
GiB — I tried it first and it OOMed four training jobs within minutes.

This PR instead splits the concatenated sequence back into per-crop blocks and attends within
each. Block-diagonal attention *is* independent attention per block, and `split` is the
documented inverse of `get_attn_bias_and_cat`, so it is mathematically identical and allocates
nothing extra.

## Verification

* bit-exact against timm at batch 1/2/4/8
* full multi-crop training path: no OOM, sustained 0.99–1.18 it/s

## Note for reviewers

Two changes met to create this, neither wrong alone: the SDPA fallback added for the fp16 NaN
guard, and the auto-disable of xformers on newer architectures. The fallback simply never
carried the mask its xformers counterpart did.

A regression test would be worth adding, but it must compare against a reference implementation
on **real images**. A random-input test does *not* catch this — noise produces near-uniform
attention that hides the missing mask, and a block-by-block activation diff on random input
matched to 1e-6 while the model was thoroughly broken.
