### PR TITLE
[TAO-2492] DINOv3: honour train.checkpoint_interval_unit='step' (re-targets #93 at main)

### DIFF
--- a/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
+++ b/nvidia_tao_pytorch/ssl/dinov3/model/pl_model.py
@@ -32,7 +32,7 @@ from nvidia_tao_pytorch.core.distributed.comm import get_global_rank
 from nvidia_tao_pytorch.core.tlt_logging import logging
 from nvidia_tao_pytorch.ssl.nvdinov2.model.head import DinoHead
 from nvidia_tao_pytorch.ssl.nvdinov2.model.loss import DinoV2Loss
-from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import DinoV2PlModel
+from nvidia_tao_pytorch.ssl.nvdinov2.model.pl_model import CustomModelCheckpoint, DinoV2PlModel
 from nvidia_tao_pytorch.ssl.dinov3.model.vit import DinoV3VisionTransformer, SwiGLUFusedFull
 from nvidia_tao_pytorch.ssl.dinov3.model.loss import GramLoss, ClsPreservationLoss
 from nvidia_tao_pytorch.ssl.dinov3.model.lora import (
@@ -920,3 +920,64 @@ class DinoV3PlModel(DinoV2PlModel):
                 losses.append(preservation_cfg.cls_cosine_weight * cls_cosine)
 
         return losses
+
+    def configure_callbacks(self):
+        """Configure callbacks, honouring ``train.checkpoint_interval_unit``.
+
+        The inherited NVDINOv2 implementation wires the periodic checkpoint with
+        ``every_n_epochs=checkpoint_interval`` only -- it never reads
+        ``checkpoint_interval_unit``, unlike the core base class, which supports both. That is
+        harmless for NVDINOv2's own recipes, but it makes step-unit checkpointing silently
+        no-op: a spec asking for "every 1000 steps" becomes "every 1000 *epochs*", i.e. never.
+
+        On a time-capped scheduler that is not a cosmetic difference. Whenever a single epoch
+        takes longer than the per-job wall-clock limit -- routine for SSL pretraining on a large
+        corpus -- an epoch boundary is never reached inside one allocation. With epoch-only
+        checkpointing a requeued run then restarts from step 0 every time and never finishes,
+        and because the periodic callback is also what writes the full Lightning checkpoint that
+        resume consumes, there is nothing to resume *from* either. Step-unit checkpointing is
+        what makes a requeue/resume loop viable at all.
+
+        The periodic callback is rebuilt through its public constructor rather than by poking
+        Lightning's private ``_every_n_*`` attributes, so this does not depend on Lightning
+        internals.
+
+        Returns:
+            Sequence[Callback]: the inherited callbacks, with the periodic checkpoint
+            re-wired to step cadence when the spec asks for it.
+        """
+        callbacks = super().configure_callbacks()
+
+        unit = self.experiment_spec["train"].get("checkpoint_interval_unit", "epoch")
+        if unit != "step":
+            return callbacks
+
+        interval = self.experiment_spec["train"]["checkpoint_interval"]
+        results_dir = self.experiment_spec["results_dir"]
+
+        rebuilt = []
+        for callback in callbacks:
+            # The periodic checkpoint is the unmonitored, keep-everything one. The best-metric
+            # callback (when enabled) is monitored, and TAOExceptionCheckpoint is a different
+            # class, so neither is touched.
+            if (isinstance(callback, CustomModelCheckpoint) and
+                    callback.monitor is None and
+                    callback.save_top_k == -1):
+                rebuilt.append(CustomModelCheckpoint(
+                    every_n_train_steps=interval,
+                    every_n_epochs=None,
+                    dirpath=results_dir,
+                    save_on_train_epoch_end=False,
+                    monitor=None,
+                    save_top_k=-1,
+                    save_last="link",
+                    filename="model_{epoch:03d}_{step:05d}",
+                    enable_version_counter=False,
+                ))
+                logging.info(
+                    "DINOv3: checkpointing every %d steps (checkpoint_interval_unit='step').",
+                    interval,
+                )
+            else:
+                rebuilt.append(callback)
+        return rebuilt


### PR DESCRIPTION
Re-targets **#93** at `main`.

#93 was reviewed and **approved**, but it was auto-closed when its base branch was merged and
deleted — so the fix never reached `main`. I only noticed because `main` now carries `lora.py`
but has zero occurrences of `checkpoint_interval_unit`. Same change, re-based; no functional
differences.

## Problem

`DinoV3PlModel` inherits `configure_callbacks` from NVDINOv2, which wires the periodic
checkpoint with `every_n_epochs=checkpoint_interval` only. It never reads
`checkpoint_interval_unit` — unlike the core base class
(`core/lightning/tao_lightning_module.py`), which supports both.

A spec asking for **"every 1000 steps" silently becomes "every 1000 epochs"**, i.e. never.

## Why it matters

Invisible on a workstation, fatal on a time-capped scheduler. Whenever a single epoch takes
longer than the per-job wall-clock limit — routine for SSL pretraining on a large corpus — the
epoch boundary is never reached inside one allocation:

* no checkpoint is ever written, and
* because the same callback also writes the full Lightning checkpoint that resume consumes,
  there is nothing to resume *from*.

Every requeued run restarts at step 0, indefinitely. Observed directly: 31 epochs into an
8-GPU run, the only artifacts were a single epoch-0 stripped `student_`/`teacher_` pair.

## Fix

Override `configure_callbacks` in `DinoV3PlModel` to rebuild the periodic callback with
`every_n_train_steps` when the spec asks for step cadence — through its **public constructor**,
not by mutating Lightning's private `_every_n_*` attributes.

## Verification

| spec | result |
|---|---|
| `unit=epoch, interval=3` | `every_n_epochs=3, every_n_train_steps=0` — **unchanged** |
| `unit=step, interval=1000` | `every_n_epochs=0, every_n_train_steps=1000` |

End-to-end on 8×H100 via a deliberate requeue/resume drill: checkpoints land on cadence, the
resumed cycle restores optimizer and EMA state, the step counter continues (100 → 175 → 200),
the loss curve is continuous across the boundary, and the post-resume checkpoint still carries
all 72 `lora_*` keys with the frozen base bit-identical (162 tensors compared, 0 drifted).

## Scope question

Scoped to the DINOv3 override deliberately. The defect is really in the inherited NVDINOv2
`configure_callbacks`, so fixing it there would also help MAE/NVDINOv2 consumers — at the cost
of a wider blast radius. Happy to move it if you prefer.
