### PR TITLE
[TAOVN-1251][Feature] Add NVPanoptix3Dv2 dataloader module

### DIFF
--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/__init__.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 dataloader module."""
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.model.build_pl_model import (
+    PANOPTIC, REASONING, SUPPORTED_MODEL_TYPES,
+)
+
+
+def build_pl_data_module(experiment_config):
+    """Build the LightningDataModule for the configured variant.
+
+    Args:
+        experiment_config: the experiment config, with ``model.model_type`` set
+            to one of ``panoptic`` or ``reasoning``.
+
+    Returns:
+        An initialized LightningDataModule reading ``dataset.<variant>``.
+    """
+    model_type = str(experiment_config.model.model_type)
+    if model_type == PANOPTIC:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.pl_data_module import (
+            build_data_module,
+        )
+        return build_data_module(
+            experiment_config.dataset.panoptic,
+            seed=experiment_config.train.seed,
+        )
+    if model_type == REASONING:
+        from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.reasoning.pl_data_module import (
+            build_data_module,
+        )
+        return build_data_module(experiment_config.dataset.reasoning)
+    raise ValueError(
+        f"Unsupported model.model_type {model_type!r}. "
+        f"Supported: {', '.join(SUPPORTED_MODEL_TYPES)}"
+    )

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ScanNet++ panoptic dataloader for the NVPanoptix3Dv2 panoptic variant."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/augmentations.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/augmentations.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Geometry-safe photometric augmentation for ScanNet++ multi-view samples."""
+
+import numpy as np
+from PIL import Image, ImageEnhance, ImageOps
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.utils import (
+    get_config_value,
+)
+
+
+class GeometrySafePhotometricAugmentation:
+    """Moderate RGB-only augmentation shared by all views of one sample.
+
+    No operation changes image dimensions or pixel coordinates. Parameters
+    are sampled once per multi-view sample, then applied identically to every
+    view so correspondence cues are not corrupted by view-specific jitter.
+    """
+
+    def __init__(self, config):
+        self.brightness = float(get_config_value(config, "brightness", 0.10))
+        self.contrast = float(get_config_value(config, "contrast", 0.10))
+        self.saturation = float(get_config_value(config, "saturation", 0.15))
+        self.gamma = float(get_config_value(config, "gamma", 0.10))
+        self.exposure_ev = float(
+            get_config_value(config, "exposure_ev", 0.15)
+        )
+        self.color_jitter_prob = float(
+            get_config_value(config, "color_jitter_prob", 0.8)
+        )
+        self.gamma_exposure_prob = float(
+            get_config_value(config, "gamma_exposure_prob", 0.5)
+        )
+        self.grayscale_prob = float(
+            get_config_value(config, "grayscale_prob", 0.05)
+        )
+
+        for name in ("brightness", "contrast", "saturation", "exposure_ev"):
+            if getattr(self, name) < 0:
+                raise ValueError(f"photometric {name} must be non-negative")
+        if not 0 <= self.gamma < 1:
+            raise ValueError("photometric gamma must be in [0, 1)")
+        for name in (
+            "color_jitter_prob", "gamma_exposure_prob", "grayscale_prob",
+        ):
+            if not 0 <= getattr(self, name) <= 1:
+                raise ValueError(f"photometric {name} must be in [0, 1]")
+
+    @classmethod
+    def from_config(cls, config):
+        """Build the augmentation from config, or None when it is disabled."""
+        if config is None or not bool(get_config_value(config, "enabled", False)):
+            return None
+        return cls(config)
+
+    def sample(self, rng):
+        """Sample one immutable recipe for a complete multi-view sample."""
+        color_ops = []
+        if rng.random() < self.color_jitter_prob:
+            color_ops = [
+                ("brightness", rng.uniform(
+                    1 - self.brightness, 1 + self.brightness,
+                )),
+                ("contrast", rng.uniform(
+                    1 - self.contrast, 1 + self.contrast,
+                )),
+                ("saturation", rng.uniform(
+                    1 - self.saturation, 1 + self.saturation,
+                )),
+            ]
+            rng.shuffle(color_ops)
+
+        gamma = 1.0
+        exposure_ev = 0.0
+        if rng.random() < self.gamma_exposure_prob:
+            gamma = rng.uniform(1 - self.gamma, 1 + self.gamma)
+            exposure_ev = rng.uniform(-self.exposure_ev, self.exposure_ev)
+
+        return {
+            "color_ops": tuple(color_ops),
+            "gamma": gamma,
+            "exposure_ev": exposure_ev,
+            "grayscale": rng.random() < self.grayscale_prob,
+        }
+
+    @staticmethod
+    def apply(img: Image.Image, recipe) -> Image.Image:
+        """Apply an RGB-only recipe without changing spatial geometry."""
+        result = img
+        enhancers = {
+            "brightness": ImageEnhance.Brightness,
+            "contrast": ImageEnhance.Contrast,
+            "saturation": ImageEnhance.Color,
+        }
+        for operation, factor in recipe["color_ops"]:
+            result = enhancers[operation](result).enhance(factor)
+
+        gamma = float(recipe["gamma"])
+        exposure_ev = float(recipe["exposure_ev"])
+        if gamma != 1.0 or exposure_ev != 0.0:
+            pixels = np.asarray(result, dtype=np.float32) / 255.0
+            pixels = np.power(np.clip(pixels, 0.0, 1.0), gamma)
+            pixels *= 2.0 ** exposure_ev
+            pixels = np.clip(np.round(pixels * 255.0), 0, 255).astype(np.uint8)
+            result = Image.fromarray(pixels)
+
+        if recipe["grayscale"]:
+            result = ImageOps.grayscale(result).convert("RGB")
+        return result

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/pl_data_module.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/pl_data_module.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2-Panoptic LightningDataModule."""
+
+import json
+import logging
+import os
+
+import pytorch_lightning as pl
+import torch
+from torch.utils.data import DataLoader
+
+from nvidia_tao_pytorch.core.distributed.comm import is_dist_avail_and_initialized
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.scannetpp import (
+    ScanNetppCollator,
+    ScanNetppDataset,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_data_module(data_cfg, seed):
+    """Build the ScanNet++ panoptic data module."""
+    return NVPanoptix3Dv2PanopticDataModule(data_cfg, seed=seed)
+
+
+def resolve_panoptic_paths(data_cfg):
+    """Resolve and validate the two preprocessed ScanNet++ split roots."""
+    resolved = {}
+    missing = []
+    for split in ("train", "val"):
+        key = f"{split}_preprocessed_root"
+        configured_root = getattr(data_cfg, key, None)
+        if not configured_root:
+            raise ValueError(f"dataset.panoptic.{key} must be set")
+        preprocessed_root = os.path.abspath(
+            os.path.expanduser(str(configured_root))
+        )
+        if not os.path.isdir(preprocessed_root):
+            missing.append(preprocessed_root)
+            resolved[split] = preprocessed_root
+            continue
+        for filename in ("all_metadata.npz", "categories.json"):
+            path = os.path.join(preprocessed_root, filename)
+            if not os.path.isfile(path):
+                missing.append(path)
+        resolved[split] = preprocessed_root
+
+    if missing:
+        details = "\n  - ".join(missing)
+        raise FileNotFoundError(
+            f"Invalid preprocessed ScanNet++ dataset; missing:\n  - {details}"
+        )
+    return resolved
+
+
+def load_categories(root):
+    """Read categories from one preprocessed ScanNet++ split."""
+    path = os.path.join(str(root), "categories.json")
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def resolve_vocabulary(data_cfg):
+    """Load and validate the single native ScanNet++ taxonomy."""
+    split_paths = resolve_panoptic_paths(data_cfg)
+    categories = load_categories(split_paths["train"])
+    val_categories = load_categories(split_paths["val"])
+    taxonomy = [
+        (category.get("id", index), category["name"], bool(category.get("isthing", True)))
+        for index, category in enumerate(categories)
+    ]
+    val_taxonomy = [
+        (category.get("id", index), category["name"], bool(category.get("isthing", True)))
+        for index, category in enumerate(val_categories)
+    ]
+    if val_taxonomy != taxonomy:
+        raise ValueError(
+            "ScanNet++ train and validation roots must use the same categories.json taxonomy"
+        )
+    vocabulary = {
+        "classes": [category["name"] for category in categories],
+        "categories": categories,
+    }
+    logger.info("Loaded %d ScanNet++ classes", len(vocabulary["classes"]))
+    return vocabulary
+
+
+class NVPanoptix3Dv2PanopticDataModule(pl.LightningDataModule):
+    """Data module for preprocessed ScanNet++ train and validation roots."""
+
+    def __init__(self, data_cfg, seed=0):
+        super().__init__()
+        self.data_cfg = data_cfg
+        self.seed = int(seed)
+        self._split_paths = resolve_panoptic_paths(data_cfg)
+        # Lightning's automatic set_epoch is disabled for this data module.
+        self._train_sampler = None
+
+    def set_train_epoch(self, epoch: int) -> None:
+        """Forward the epoch to the distributed train sampler."""
+        sampler = getattr(self, "_train_sampler", None)
+        if sampler is not None and hasattr(sampler, "set_epoch"):
+            sampler.set_epoch(int(epoch))
+
+    def resolve_split_paths(self, split):
+        """Return the validated preprocessed root for a split."""
+        split_paths = getattr(self, "_split_paths", None)
+        if split_paths is None:
+            split_paths = resolve_panoptic_paths(self.data_cfg)
+            self._split_paths = split_paths
+        return split_paths[split]
+
+    def build_dataset(self, split="train"):
+        """Build the fixed ScanNet++ train or validation dataset."""
+        if split not in {"train", "val"}:
+            raise ValueError(f"Unsupported ScanNet++ split: {split!r}")
+
+        resolution = [(int(size[0]), int(size[1])) for size in self.data_cfg.resolution]
+        preprocessed_root = self.resolve_split_paths(split)
+        return ScanNetppDataset(
+            preprocessed_root=preprocessed_root,
+            split=split,
+            num_views=getattr(self.data_cfg, "num_views", 5),
+            resolution=resolution,
+            pairs_per_scene=getattr(self.data_cfg, "pairs_per_scene", 50),
+            randomize_view_order=getattr(
+                self.data_cfg, "randomize_view_order", True,
+            ),
+            seed=self.seed,
+            photometric_augmentation=(
+                getattr(self.data_cfg, "photometric_augmentation", None)
+                if split == "train" else None
+            ),
+        )
+
+    def common_dataloader(self, split="train", shuffle=True):
+        """Build a train or validation dataloader."""
+        dataset = self.build_dataset(split)
+
+        batch_size = getattr(self.data_cfg, "batch_size", 1)
+        num_workers = int(getattr(self.data_cfg, "num_workers", 8))
+
+        if is_dist_avail_and_initialized():
+            sampler = torch.utils.data.distributed.DistributedSampler(
+                dataset, shuffle=shuffle,
+            )
+        elif shuffle:
+            sampler = torch.utils.data.RandomSampler(dataset)
+        else:
+            sampler = torch.utils.data.SequentialSampler(dataset)
+
+        if split == "train":
+            self._train_sampler = sampler
+
+        collate_fn = ScanNetppCollator(classes=dataset.classes)
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=collate_fn,
+            num_workers=num_workers,
+            drop_last=(split == "train"),
+            pin_memory=True,
+            sampler=sampler,
+            persistent_workers=(num_workers > 0),
+            timeout=600 if num_workers > 0 else 0,
+            prefetch_factor=2 if num_workers > 0 else None,
+        )
+
+    def train_dataloader(self):
+        """Build the training dataloader."""
+        return self.common_dataloader(split="train", shuffle=True)
+
+    def val_dataloader(self):
+        """Build the validation dataloader."""
+        return self.common_dataloader(split="val", shuffle=False)
+
+    def test_dataloader(self):
+        """Evaluate on the ScanNet++ validation split."""
+        return self.common_dataloader(split="val", shuffle=False)
+
+    def predict_dataloader(self):
+        """Run inference on the ScanNet++ validation split."""
+        return self.common_dataloader(split="val", shuffle=False)

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/scannetpp.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/panoptic/scannetpp.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ScanNet++ v2 dataset for NVPanoptix3Dv2 panoptic variant."""
+
+import json
+import os.path as osp
+import random
+import sys
+import traceback
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.utils import (
+    center_crop_and_resize,
+    normalize_resolution_arg,
+    rgb2id,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.panoptic.augmentations import (
+    GeometrySafePhotometricAugmentation,
+)
+
+_MAX_GETITEM_RETRIES = 5
+
+
+def orient_resolution_bucket(
+    img_w: int, img_h: int, buckets: List[Tuple[int, int]],
+) -> Tuple[int, int]:
+    """Pick the aspect-closest bucket and orient it to the image.
+
+    Each bucket is treated as an unordered ``{long, short}`` aspect class
+    (mirroring PanSt3R, which stores landscape buckets and transposes them
+    for portrait inputs). We pick the bucket whose long/short ratio is
+    closest to the image's, then orient it so the returned ``(H, W)`` matches
+    the image's orientation -- landscape image -> wide target, portrait image
+    -> tall target. This keeps the chosen frame aspect-matched to the source
+    so the subsequent fit+pad in ``center_crop_and_resize`` adds only a
+    small border (vs ~25-33% for a forced square), which both preserves the
+    full field of view and minimises the padding the frozen VGGT backbone
+    has to process.
+
+    With a single bucket this just returns that bucket (oriented), so the
+    single-resolution path is unchanged in aspect.
+    """
+    img_long = max(img_w, img_h)
+    img_short = max(min(img_w, img_h), 1)
+    img_ratio = img_long / img_short
+    landscape = img_w >= img_h
+
+    best = None
+    best_d = float("inf")
+    for (bh, bw) in buckets:
+        b_long = max(bh, bw)
+        b_short = max(min(bh, bw), 1)
+        d = abs(b_long / b_short - img_ratio)
+        if d < best_d:
+            best_d = d
+            best = (b_long, b_short)
+
+    b_long, b_short = best
+    # Orient: (H, W) = (short, long) for landscape, (long, short) for portrait.
+    return (b_short, b_long) if landscape else (b_long, b_short)
+
+
+class ScanNetppDataset(Dataset):
+    """
+    Multi-view ScanNet++ v2 dataset for NVPanoptix3Dv2 training.
+
+    Reads preprocessed images, depth, panoptic maps and metadata from a
+    single split-aware directory (``preprocessed_root``).
+
+    Each sample returns a ``List[Dict]`` of ``num_views`` view dicts.
+
+    Sampling strategy (scene-based, like PanSt3R):
+      - Each epoch visits every scene ``pairs_per_scene`` times.
+      - Each visit randomly samples a pair from the scene's pair pool.
+      - During training, either anchor can become reference view 0 and the
+        remaining views are shuffled (when ``randomize_view_order=True``).
+      - Validation/test sampling is deterministic for every dataset index.
+      - Epoch length = num_scenes * pairs_per_scene.
+    """
+
+    def __init__(
+        self,
+        preprocessed_root: str,
+        split: str = "train",
+        num_views: int = 5,
+        resolution: Tuple[int, int] = (518, 518),
+        pairs_per_scene: int = 50,
+        randomize_view_order: bool = False,
+        seed: int = 0,
+        photometric_augmentation=None,
+    ):
+        super().__init__()
+        self.num_views = num_views
+        # ``resolution`` may be a single (H, W) tuple or a list of buckets.
+        # All views of a given sample share one bucket (chosen per-sample by
+        # the anchor view's aspect ratio); ``self.resolution`` keeps the
+        # first bucket as the back-compat single-resolution fallback.
+        self.res_buckets = normalize_resolution_arg(resolution)
+        self.resolution = self.res_buckets[0]
+        self.pairs_per_scene = pairs_per_scene
+        self.split = split
+        self.randomize_view_order = bool(randomize_view_order)
+        self.seed = int(seed)
+        self.photometric_augmentation = (
+            GeometrySafePhotometricAugmentation.from_config(
+                photometric_augmentation
+            )
+            if split == "train" else None
+        )
+
+        self.preprocessed_root = preprocessed_root
+        if not osp.isfile(osp.join(self.preprocessed_root, "all_metadata.npz")):
+            raise FileNotFoundError(
+                f"Could not find all_metadata.npz under {preprocessed_root!r}."
+            )
+
+        # Class vocabulary from preprocessing
+        cat_path = osp.join(self.preprocessed_root, "categories.json")
+        with open(cat_path) as f:
+            self.categories = json.load(f)
+        self.classes = [c["name"] for c in self.categories]
+
+        # Global metadata
+        meta_path = osp.join(self.preprocessed_root, "all_metadata.npz")
+        with np.load(meta_path, allow_pickle=True) as data:
+            self.scenes = list(data["scenes"])
+            self.sceneids = data["sceneids"].astype(int)
+            self.images = list(data["images"])
+            self.intrinsics = data["intrinsics"].astype(np.float32)
+            self.trajectories = data["trajectories"].astype(np.float32)
+            # pairs columns: [idx1, idx2, score]; we only need the indices
+            self.pairs = data["pairs"][:, :2].astype(int)
+            self.cls_sep = int(data["cls_sep"])
+
+        # ── Validate image existence: drop images & pairs for missing files
+        self.filter_missing_images()
+
+        # Per-image pair lookup (for multi-view tuple selection)
+        n_images = len(self.images)
+        self.pairs_per_image: List[set] = [set() for _ in range(n_images)]
+        for idx1, idx2 in self.pairs:
+            self.pairs_per_image[idx1].add(idx2)
+            self.pairs_per_image[idx2].add(idx1)
+
+        # Per-scene pair index lists (for scene-based sampling)
+        self._scene_pair_indices: List[List[int]] = [[] for _ in range(len(self.scenes))]
+        for pair_idx, (i1, _) in enumerate(self.pairs):
+            self._scene_pair_indices[self.sceneids[i1]].append(pair_idx)
+
+    # Camera & path helpers
+
+    def scene_dir(self, view_idx: int) -> str:
+        """Return the scene directory containing ``view_idx``."""
+        scene_id = self.scenes[self.sceneids[view_idx]]
+        return osp.join(self.preprocessed_root, scene_id)
+
+    def image_path(self, view_idx: int) -> str:
+        """Return the on-disk image path for an image index."""
+        stem = self.images[view_idx]
+        return osp.join(self.scene_dir(view_idx), "images", stem + ".jpg")
+
+    def depth_path(self, view_idx: int) -> Optional[str]:
+        """Return the on-disk depth path for an image index, or None if missing.
+
+        Both DSLR and iPhone share the same per-scene depth directory with a
+        uint16 mm encoding.
+        """
+        stem = self.images[view_idx]
+        path = osp.join(self.scene_dir(view_idx), "depth", stem + ".png")
+        return path if osp.exists(path) else None
+
+    def panoptic_path(self, view_idx: int) -> str:
+        """Return the panoptic-label path for ``view_idx``."""
+        scene_id = self.scenes[self.sceneids[view_idx]]
+        stem = self.images[view_idx]
+        return osp.join(self.preprocessed_root, scene_id, "panoptic", stem + ".png")
+
+    def filter_missing_images(self):
+        """Remove images whose files are absent and drop referencing pairs."""
+        n_before = len(self.images)
+        keep = np.array([osp.exists(self.image_path(i))
+                         for i in range(n_before)])
+        n_missing = int(n_before - keep.sum())
+        if n_missing == 0:
+            return
+
+        old_to_new = np.full(n_before, -1, dtype=np.int64)
+        new_idx = np.where(keep)[0]
+        for new_i, old_i in enumerate(new_idx):
+            old_to_new[old_i] = new_i
+
+        self.images = [self.images[i] for i in new_idx]
+        self.intrinsics = self.intrinsics[new_idx]
+        self.trajectories = self.trajectories[new_idx]
+        self.sceneids = self.sceneids[new_idx]
+
+        new_pairs = []
+        for i1, i2 in self.pairs:
+            n1, n2 = old_to_new[i1], old_to_new[i2]
+            if n1 >= 0 and n2 >= 0:
+                new_pairs.append([n1, n2])
+        self.pairs = np.array(new_pairs, dtype=np.int64) if new_pairs \
+            else np.zeros((0, 2), dtype=np.int64)
+
+    def __len__(self) -> int:
+        """Return the number of multi-view samples the split exposes."""
+        return len(self.scenes) * self.pairs_per_scene
+
+    # Multi-view tuple selection
+
+    def select_views(self, idx1: int, idx2: int, rng=None) -> List[int]:
+        """Pick ``num_views`` image indices around the anchor pair.
+
+        ``rng`` may be the module-level :mod:`random` generator for training
+        or an index-seeded :class:`random.Random` instance for deterministic
+        validation/test sampling.
+        """
+        rng = random if rng is None else rng
+        selected = [idx1, idx2]
+        selected_set = set(selected)
+
+        # Sort before shuffling so an index-seeded RNG produces the same
+        # order across processes and Python hash seeds.
+        candidates = sorted(self.pairs_per_image[idx1] |
+                            self.pairs_per_image[idx2])
+        rng.shuffle(candidates)
+
+        for c in candidates:
+            if len(selected) >= self.num_views:
+                break
+            if c not in selected_set:
+                selected.append(c)
+                selected_set.add(c)
+
+        while len(selected) < self.num_views:
+            selected.append(selected[len(selected) % len(selected)])
+
+        return selected[:self.num_views]
+
+    def augment_training_view_order(self, view_indices: List[int], rng=None) -> List[int]:
+        """Randomise reference/tail order without choosing a weak reference.
+
+        The first two entries are the central, directly-overlapping anchor
+        pair. Pick either anchor as reference view 0, then shuffle every
+        remaining view. Auxiliary neighbours are never promoted to reference
+        because each is only guaranteed to overlap at least one anchor.
+        """
+        ordered = list(view_indices)
+        if (
+            self.split != "train" or
+            not self.randomize_view_order or
+            len(ordered) < 2
+        ):
+            return ordered
+
+        rng = random if rng is None else rng
+        if rng.random() < 0.5:
+            ordered[0], ordered[1] = ordered[1], ordered[0]
+        tail = ordered[1:]
+        rng.shuffle(tail)
+        return [ordered[0], *tail]
+
+    def sampling_rng(self, idx: int):
+        """Return stochastic train RNG or a stable per-index eval RNG."""
+        if self.split == "train":
+            return random
+        return random.Random(self.seed + int(idx))
+
+    # View loading
+
+    def load_view(
+        self,
+        view_idx: int,
+        target_res: Optional[Tuple[int, int]] = None,
+        photometric_recipe=None,
+    ) -> Dict:
+        """Load and spatially align all modalities for one view."""
+        scene_id = self.scenes[self.sceneids[view_idx]]
+        stem = self.images[view_idx]
+        K = self.intrinsics[view_idx].copy()
+        E = self.trajectories[view_idx].copy()
+
+        tgt_h, tgt_w = target_res if target_res is not None else self.resolution
+
+        # RGB
+        img = Image.open(self.image_path(view_idx)).convert("RGB")
+        if (
+            self.photometric_augmentation is not None and
+            photometric_recipe is not None
+        ):
+            # Applied before resize/padding so the geometry transform and K
+            # update remain identical, while synthetic white padding stays
+            # exactly white.
+            img = self.photometric_augmentation.apply(img, photometric_recipe)
+
+        # ScanNet++ depth PNGs are uint16 millimetres; convert to metres.
+        depth_path = self.depth_path(view_idx)
+        if depth_path is not None:
+            depth = np.array(Image.open(depth_path), dtype=np.float32)
+            depth /= 1000.0
+            depth[~np.isfinite(depth)] = 0.0
+        else:
+            W, H = img.size
+            depth = np.zeros((H, W), dtype=np.float32)
+
+        # Panoptic map
+        pan_path = self.panoptic_path(view_idx)
+        if osp.exists(pan_path):
+            pan_rgb = np.array(Image.open(pan_path))
+            pan_id = rgb2id(pan_rgb)
+        else:
+            pan_id = None
+
+        # PP-centred crop + uniform resize
+        img, K, depth, pan_id = center_crop_and_resize(
+            img, K, depth, pan_id, (tgt_h, tgt_w))
+
+        img_np = np.array(img, dtype=np.float32) / 255.0
+        img_tensor = torch.from_numpy(img_np).permute(2, 0, 1)
+
+        if pan_id is not None:
+            inst_id = pan_id // self.cls_sep
+            cls_id = pan_id % self.cls_sep
+        else:
+            inst_id = np.zeros((tgt_h, tgt_w), dtype=np.int32)
+            cls_id = np.zeros((tgt_h, tgt_w), dtype=np.int32)
+
+        view = {
+            "img": img_tensor,
+            "true_shape": torch.tensor([tgt_h, tgt_w], dtype=torch.int32),
+            "depthmap": torch.from_numpy(depth),
+            "camera_intrinsics": torch.from_numpy(K),
+            "camera_pose": torch.from_numpy(E),
+            "intrinsics": torch.from_numpy(K),
+            "extrinsics": torch.from_numpy(E),
+            "pan_inst_id": torch.from_numpy(inst_id.astype(np.int64)),
+            "pan_cls_id": torch.from_numpy(cls_id.astype(np.int64)),
+            "dataset": "ScanNet++",
+            "label": f"{scene_id}_{stem}",
+        }
+        return view
+
+    def __getitem__(self, idx: int) -> List[Dict]:
+        """Return one multi-view sample as a list of per-view dicts."""
+        # Training retains bounded retries for transient I/O errors. Eval is
+        # deliberately fail-fast: silently replacing a validation sample
+        # makes metrics stochastic and can hide corrupt manifests.
+        max_attempts = _MAX_GETITEM_RETRIES if self.split == "train" else 1
+        for attempt in range(max_attempts):
+            sampling_rng = self.sampling_rng(idx)
+            scene_idx = idx % len(self.scenes)
+
+            try:
+                pair_list = self._scene_pair_indices[scene_idx]
+                if not pair_list:
+                    fallback = [si for si in range(len(self.scenes))
+                                if self._scene_pair_indices[si]]
+                    if not fallback:
+                        raise RuntimeError("All scenes have 0 pairs")
+                    scene_idx = sampling_rng.choice(fallback)
+                    pair_list = self._scene_pair_indices[scene_idx]
+
+                pair_idx = sampling_rng.choice(pair_list)
+                idx1, idx2 = self.pairs[pair_idx]
+
+                view_indices = self.select_views(idx1, idx2, rng=sampling_rng)
+                view_indices = self.augment_training_view_order(
+                    view_indices, rng=sampling_rng,
+                )
+
+                # One resolution bucket for the whole sample, chosen from the
+                # anchor view's aspect ratio (header-only read, no decode), so
+                # the stacked multi-view tensor is consistent. Orient the bucket
+                # even when there is only one, or portrait sources get forced
+                # through a landscape target.
+                with Image.open(self.image_path(view_indices[0])) as _im:
+                    aw, ah = _im.size
+                target_res = orient_resolution_bucket(aw, ah, self.res_buckets)
+
+                photometric_recipe = (
+                    self.photometric_augmentation.sample(sampling_rng)
+                    if self.photometric_augmentation is not None else None
+                )
+                views = [
+                    self.load_view(
+                        view_index,
+                        target_res=target_res,
+                        photometric_recipe=photometric_recipe,
+                    )
+                    for view_index in view_indices
+                ]
+
+                return views
+            except Exception:
+                if attempt == max_attempts - 1:
+                    traceback.print_exc(file=sys.stderr)
+                    raise
+                idx = random.randint(0, len(self) - 1)
+
+        # Unreachable: the final attempt either returns or raises above. Kept so
+        # every path out of the method is explicit.
+        raise RuntimeError(
+            f"__getitem__ exhausted {max_attempts} attempts for idx={idx}"
+        )
+
+
+class ScanNetppCollator:
+    """Stack a ScanNet++ batch and attach its fixed class vocabulary."""
+
+    def __init__(self, classes: List[str]):
+        self.classes = list(classes)
+
+    def __call__(self, batch_list):
+        """Return a view-major batch with the native ScanNet++ vocabulary."""
+        batch_size = len(batch_list)
+        num_views = len(batch_list[0])
+        collated = []
+
+        for view_index in range(num_views):
+            view_dicts = [batch_list[index][view_index] for index in range(batch_size)]
+            out = {}
+            for key in view_dicts[0]:
+                values = [view[key] for view in view_dicts]
+                if isinstance(values[0], torch.Tensor):
+                    out[key] = torch.stack(values, dim=0)
+                elif isinstance(values[0], str):
+                    out[key] = values
+                else:
+                    out[key] = values
+            collated.append(out)
+
+        collated[0]["vocab"] = list(self.classes)
+        return collated

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/__init__.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning-manifest dataloader for the NVPanoptix3Dv2 reasoning variant."""

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/pl_data_module.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/pl_data_module.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2-Reasoning LightningDataModule."""
+
+from __future__ import annotations
+
+import pytorch_lightning as pl
+from torch.utils.data import DataLoader
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.utils import (
+    get_config_value,
+)
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.reasoning.reasoning_dataset import (
+    ReasoningCollator, ReasoningSegDataset
+)
+
+
+def build_data_module(data_cfg):
+    """Factory used by ``scripts/train_sam.py``."""
+    return NVPanoptix3Dv2ReasoningDataModule(data_cfg)
+
+
+class NVPanoptix3Dv2ReasoningDataModule(pl.LightningDataModule):
+    """Builds train/val :class:`ReasoningSegDataset` loaders from the data config.
+
+    Expected ``dataset`` config keys::
+
+        train_manifest: /path/to/train.jsonl   # required
+        val_manifest:   /path/to/val.jsonl     # optional
+        resolution:     [518, 518]             # single (H, W) or bucket list
+        num_views:      5
+        batch_size:     1
+        num_workers:    4
+        depth_scale:    1000.0                 # stored units per meter
+    """
+
+    def __init__(self, data_cfg):
+        super().__init__()
+        self.data_cfg = data_cfg
+        self.resolution = get_config_value(data_cfg, "resolution", [518, 518])
+        self.num_views = get_config_value(data_cfg, "num_views", 5)
+        self.batch_size = int(get_config_value(data_cfg, "batch_size", 1))
+        self.num_workers = int(get_config_value(data_cfg, "num_workers", 4))
+        self.depth_scale = float(get_config_value(data_cfg, "depth_scale", 1000.0))
+        self.collator = ReasoningCollator()
+
+        train_manifest = get_config_value(data_cfg, "train_manifest", None)
+        if not train_manifest:
+            raise ValueError("dataset.train_manifest is required for NVPanoptix3Dv2-Reasoning")
+        self.train_ds = ReasoningSegDataset(
+            manifest=train_manifest,
+            resolution=self.resolution,
+            num_views=self.num_views,
+            require_seg_token=bool(
+                get_config_value(data_cfg, "require_seg_token", True)
+            ),
+            depth_scale=self.depth_scale,
+        )
+        val_manifest = get_config_value(data_cfg, "val_manifest", None)
+        self.val_ds = (
+            ReasoningSegDataset(
+                manifest=val_manifest,
+                resolution=self.resolution,
+                num_views=self.num_views,
+                depth_scale=self.depth_scale,
+            )
+            if val_manifest
+            else None
+        )
+        # Kept for TAO training code that expects datamodules to expose classes.
+        self.classes = []
+
+    def train_dataloader(self):
+        """Training loader (shuffled)."""
+        return DataLoader(
+            self.train_ds,
+            batch_size=self.batch_size,
+            shuffle=True,
+            num_workers=self.num_workers,
+            collate_fn=self.collator,
+            pin_memory=True,
+            drop_last=True,
+            persistent_workers=self.num_workers > 0,
+        )
+
+    def val_dataloader(self):
+        """Validation loader (or ``None`` if no val manifest)."""
+        if self.val_ds is None:
+            return None
+        return DataLoader(
+            self.val_ds,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            collate_fn=self.collator,
+            pin_memory=True,
+            drop_last=False,
+            persistent_workers=self.num_workers > 0,
+        )
+
+    def test_dataloader(self):
+        """Evaluation loader. The reasoning variant scores the val manifest."""
+        return self.val_dataloader()
+
+    def predict_dataloader(self):
+        """Inference loader. The reasoning variant predicts over the val manifest."""
+        return self.val_dataloader()

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/reasoning_dataset.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/reasoning/reasoning_dataset.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning-segmentation dataset and collator, read from a JSONL manifest."""
+
+from __future__ import annotations
+
+import json
+import os.path as osp
+import random
+import sys
+import traceback
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from nvidia_tao_pytorch.cv.nvpanoptix3d_v2.dataloader.utils import (
+    center_crop_and_resize,
+    normalize_resolution_arg,
+    rgb2id,
+)
+
+SEG_TOKEN = "[SEG]"
+_MAX_GETITEM_RETRIES = 5
+
+
+def resolve_manifest_path(path: Optional[str], manifest_dir: str) -> Optional[str]:
+    """Resolve relative assets next to the manifest and preserve absolute paths."""
+    if path is None:
+        return None
+    value = str(path)
+    if not osp.isabs(value):
+        value = osp.join(manifest_dir, value)
+    return osp.normpath(value)
+
+
+class ReasoningSegDataset(Dataset):
+    """Reads a JSONL manifest of (multi-view scene, implicit query) samples.
+
+    Args:
+        manifest: path to the JSONL manifest (see module docstring).
+        resolution: target ``(H, W)`` (single tuple). All views resized to it.
+        num_views: expected views per sample; samples with fewer are padded by
+            repeating the last view, more are truncated (keeps batch stacking
+            uniform). Set ``None`` to require exact match.
+        require_seg_token: if True, drop manifest rows whose ``answer`` lacks
+            ``[SEG]`` (and have a positive ``target_inst_id``); kept otherwise.
+        depth_scale: stored depth units per meter.
+    """
+
+    def __init__(
+        self,
+        manifest: str,
+        resolution: Tuple[int, int] = (518, 518),
+        num_views: Optional[int] = 5,
+        require_seg_token: bool = False,
+        depth_scale: float = 1000.0,
+    ):
+        super().__init__()
+        self.manifest_path = manifest
+        self.resolution = normalize_resolution_arg(resolution)[0]
+        self.num_views = num_views
+        self.require_seg_token = require_seg_token
+        self.depth_scale = float(depth_scale)
+        if self.depth_scale <= 0:
+            raise ValueError(f"depth_scale must be positive, got {depth_scale!r}")
+        self.records: List[Dict[str, Any]] = self.load_manifest(manifest)
+
+    def load_manifest(self, path: str) -> List[Dict[str, Any]]:
+        """Load, validate, and resolve asset paths in a JSONL manifest."""
+        recs: List[Dict[str, Any]] = []
+        manifest_dir = osp.dirname(osp.abspath(path))
+        with open(path) as f:
+            for ln, line in enumerate(f):
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                if "images" not in rec or "instruction" not in rec or "answer" not in rec:
+                    raise ValueError(
+                        f"{path}:{ln+1} manifest record missing required keys "
+                        f"(images/instruction/answer)."
+                    )
+                rec = dict(rec)
+                if self.require_seg_token and int(rec.get("target_inst_id", 0)) > 0 \
+                        and SEG_TOKEN not in rec["answer"]:
+                    continue
+                record_scale = float(rec.get("depth_scale", self.depth_scale))
+                if record_scale <= 0:
+                    raise ValueError(
+                        "record depth_scale must be positive, "
+                        f"got {record_scale!r} at {path}:{ln + 1}"
+                    )
+                images = [
+                    resolve_manifest_path(asset, manifest_dir)
+                    for asset in rec["images"]
+                ]
+                pans = rec.get("panoptic")
+                if pans is not None:
+                    pans = [
+                        resolve_manifest_path(asset, manifest_dir)
+                        for asset in pans
+                    ]
+                depths = rec.get("depth")
+                if depths is None:
+                    depths = [None] * len(images)
+                else:
+                    depths = list(depths)
+                depths = [
+                    resolve_manifest_path(asset, manifest_dir)
+                    for asset in depths
+                ]
+                rec["images"] = images
+                rec["panoptic"] = pans
+                rec["depth"] = depths
+                rec["_depth_scale"] = record_scale
+                recs.append(rec)
+        if not recs:
+            raise RuntimeError(f"No usable records in manifest {path}")
+        return recs
+
+    def __len__(self) -> int:
+        """Return the number of manifest records."""
+        return len(self.records)
+
+    def fit_num_views(self, paths: List[str]) -> List[int]:
+        """Return index list of length ``num_views`` (pad/truncate)."""
+        n = len(paths)
+        if self.num_views is None:
+            return list(range(n))
+        if n >= self.num_views:
+            return list(range(self.num_views))
+        return list(range(n)) + [n - 1] * (self.num_views - n)  # repeat last
+
+    def load_view(
+        self,
+        img_path: str,
+        pan_path: Optional[str],
+        depth_path: Optional[str],
+        cls_sep: int,
+        depth_scale: float,
+    ) -> Dict[str, Any]:
+        """Load and align one reasoning sample view and its annotations."""
+        tgt_h, tgt_w = self.resolution
+        img = Image.open(img_path).convert("RGB")
+        W, H = img.size
+
+        if pan_path:
+            pan_rgb = np.array(Image.open(pan_path))
+            pan_id = rgb2id(pan_rgb).astype(np.int32)
+        else:
+            pan_id = np.zeros((H, W), dtype=np.int32)
+
+        if depth_path:
+            depth = np.array(Image.open(depth_path), dtype=np.float32)
+            depth /= depth_scale
+            depth[~np.isfinite(depth)] = 0.0
+        else:
+            depth = np.zeros((H, W), dtype=np.float32)
+
+        # Centered default intrinsics so the PP-crop degenerates to a center crop.
+        K = np.array([[max(H, W), 0, W / 2.0],
+                      [0, max(H, W), H / 2.0],
+                      [0, 0, 1.0]], dtype=np.float32)
+
+        img, K, depth, pan_id = center_crop_and_resize(
+            img, K, depth, pan_id, (tgt_h, tgt_w)
+        )
+
+        img_np = np.array(img, dtype=np.float32) / 255.0
+        img_t = torch.from_numpy(img_np).permute(2, 0, 1)
+        inst_id = (pan_id // cls_sep).astype(np.int64) if pan_id is not None \
+            else np.zeros((tgt_h, tgt_w), dtype=np.int64)
+        return {
+            "img": img_t,
+            "true_shape": torch.tensor([tgt_h, tgt_w], dtype=torch.int32),
+            "pan_inst_id": torch.from_numpy(inst_id),
+            "depthmap": torch.from_numpy(depth),
+        }
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        """Return one multi-view reasoning sample."""
+        for attempt in range(_MAX_GETITEM_RETRIES):
+            rec = self.records[idx % len(self.records)]
+            try:
+                cls_sep = int(rec.get("cls_sep", 256))
+                depth_scale = float(rec.get("_depth_scale", self.depth_scale))
+                view_idx = self.fit_num_views(rec["images"])
+                pans = rec.get("panoptic") or [None] * len(rec["images"])
+                depths = rec.get("depth") or [None] * len(rec["images"])
+                views = [
+                    self.load_view(
+                        rec["images"][i],
+                        pans[i] if i < len(pans) else None,
+                        depths[i] if i < len(depths) else None,
+                        cls_sep,
+                        depth_scale,
+                    )
+                    for i in view_idx
+                ]
+                target = int(rec.get("target_inst_id") or 0)
+                raw_svi = rec.get("seg_view_indices")
+                if raw_svi is None:
+                    seg_view_indices = [0]
+                else:
+                    kept = len(view_idx)  # views actually loaded (after pad/truncate)
+                    seg_view_indices = [int(v) for v in raw_svi if 0 <= int(v) < kept]
+                    if not seg_view_indices:
+                        seg_view_indices = [0]
+                return {
+                    "views": views,
+                    "instruction": str(rec["instruction"]),
+                    "answer": str(rec["answer"]),
+                    "target_inst_id": target,
+                    "seg_view_indices": seg_view_indices,
+                    "scene": str(rec.get("scene", "")),
+                }
+            except Exception:  # pragma: no cover
+                if attempt == _MAX_GETITEM_RETRIES - 1:
+                    traceback.print_exc(file=sys.stderr)
+                    raise
+                idx = random.randint(0, len(self) - 1)
+
+        # Unreachable: the final attempt either returns or raises above. Kept
+        # so every path out of the method is explicit.
+        raise RuntimeError(f"__getitem__ exhausted all attempts for idx={idx}")
+
+
+class ReasoningCollator:
+    """Collate samples into a per-view list with QA attached to view 0.
+
+    Returns ``List[S]`` of dicts; view ``s`` has stacked tensors
+    ``img`` ``[B,3,H,W]``, ``true_shape`` ``[B,2]``, ``pan_inst_id`` ``[B,H,W]``,
+    and ``depthmap`` ``[B,H,W]``.
+    The first view dict additionally carries the batch QA:
+      * ``instruction``    : ``List[str]`` length B
+      * ``answer``         : ``List[str]`` length B
+      * ``target_inst_id`` : ``LongTensor[B]``
+    """
+
+    def __call__(self, samples: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Collate samples into the per-view dict list the model consumes."""
+        if not samples:
+            raise ValueError("empty batch")
+        S = len(samples[0]["views"])
+        if any(len(s["views"]) != S for s in samples):
+            raise ValueError(
+                "All samples in a batch must have the same number of views; "
+                "set dataset.num_views to enforce this."
+            )
+        out: List[Dict[str, Any]] = []
+        for s in range(S):
+            view = {
+                "img": torch.stack([smp["views"][s]["img"] for smp in samples], dim=0),
+                "true_shape": torch.stack(
+                    [smp["views"][s]["true_shape"] for smp in samples], dim=0
+                ),
+                "pan_inst_id": torch.stack(
+                    [smp["views"][s]["pan_inst_id"] for smp in samples], dim=0
+                ),
+                "depthmap": torch.stack(
+                    [smp["views"][s]["depthmap"] for smp in samples], dim=0
+                ),
+            }
+            out.append(view)
+        out[0]["instruction"] = [smp["instruction"] for smp in samples]
+        out[0]["answer"] = [smp["answer"] for smp in samples]
+        out[0]["target_inst_id"] = torch.tensor(
+            [smp["target_inst_id"] for smp in samples], dtype=torch.long
+        )
+        out[0]["scene"] = [smp["scene"] for smp in samples]
+        out[0]["seg_view_indices"] = [smp["seg_view_indices"] for smp in samples]
+        return out

--- a/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/utils.py
+++ b/nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader/utils.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities shared by both NVPanoptix3Dv2 dataloader variants."""
+
+from typing import List, Tuple
+
+import numpy as np
+from PIL import Image
+
+
+def get_config_value(config, key, default=None):
+    """Read a key from a dictionary or an attribute-based config object."""
+    if config is None:
+        return default
+    if hasattr(config, key):
+        return getattr(config, key)
+    if isinstance(config, dict):
+        return config.get(key, default)
+    return default
+
+
+def center_crop_and_resize(
+    img: Image.Image,
+    intrinsics: np.ndarray,
+    depth: np.ndarray,
+    panoptic_id,
+    target_hw: Tuple[int, int],
+):
+    """Principal-point crop, aspect-preserving resize, and center padding.
+
+    The transform preserves spatial correspondence among RGB, depth, panoptic
+    labels, and camera intrinsics. ``intrinsics`` is modified in place.
+    """
+    target_h, target_w = target_hw
+    image_w, image_h = img.size
+
+    center_x = int(round(intrinsics[0, 2]))
+    center_y = int(round(intrinsics[1, 2]))
+    margin_x = min(center_x, image_w - center_x)
+    margin_y = min(center_y, image_h - center_y)
+
+    left, top = center_x - margin_x, center_y - margin_y
+    right, bottom = center_x + margin_x, center_y + margin_y
+
+    img = img.crop((left, top, right, bottom))
+    depth = depth[top:bottom, left:right]
+    if panoptic_id is not None:
+        panoptic_id = panoptic_id[top:bottom, left:right]
+    intrinsics[0, 2] -= left
+    intrinsics[1, 2] -= top
+
+    crop_w, crop_h = img.size
+    scale = min(target_w / crop_w, target_h / crop_h)
+    new_w = max(1, min(target_w, round(crop_w * scale)))
+    new_h = max(1, min(target_h, round(crop_h * scale)))
+
+    img = img.resize((new_w, new_h), Image.LANCZOS)
+    # Nearest-neighbor interpolation keeps invalid depth at zero and preserves
+    # real values at depth discontinuities.
+    depth = np.array(
+        Image.fromarray(depth).resize((new_w, new_h), Image.NEAREST),
+        dtype=np.float32,
+    )
+    if panoptic_id is not None:
+        panoptic_id = np.array(
+            Image.fromarray(panoptic_id.astype(np.int32)).resize(
+                (new_w, new_h), Image.NEAREST,
+            ),
+            dtype=np.int32,
+        )
+    intrinsics[0, :] *= new_w / crop_w
+    intrinsics[1, :] *= new_h / crop_h
+
+    pad_left = (target_w - new_w) // 2
+    pad_top = (target_h - new_h) // 2
+
+    image_canvas = Image.new("RGB", (target_w, target_h), (255, 255, 255))
+    image_canvas.paste(img, (pad_left, pad_top))
+    img = image_canvas
+
+    depth_canvas = np.zeros((target_h, target_w), dtype=np.float32)
+    depth_canvas[pad_top:pad_top + new_h, pad_left:pad_left + new_w] = depth
+    depth = depth_canvas
+
+    if panoptic_id is not None:
+        panoptic_canvas = np.zeros((target_h, target_w), dtype=np.int32)
+        panoptic_canvas[
+            pad_top:pad_top + new_h, pad_left:pad_left + new_w
+        ] = panoptic_id
+        panoptic_id = panoptic_canvas
+
+    intrinsics[0, 2] += pad_left
+    intrinsics[1, 2] += pad_top
+    return img, intrinsics, depth, panoptic_id
+
+
+def rgb2id(rgb: np.ndarray) -> np.ndarray:
+    """Decode an RGB-encoded ScanNet++ panoptic ID map."""
+    return (
+        rgb[..., 0].astype(np.int32) +
+        256 * rgb[..., 1].astype(np.int32) +
+        65536 * rgb[..., 2].astype(np.int32)
+    )
+
+
+def normalize_resolution_arg(resolution) -> List[Tuple[int, int]]:
+    """Normalize one ``(H, W)`` pair or a list of resolution pairs."""
+    if resolution is None:
+        raise ValueError("resolution must not be None")
+    first = resolution[0]
+    if isinstance(first, (list, tuple)):
+        buckets = [(int(value[0]), int(value[1])) for value in resolution]
+    else:
+        buckets = [(int(resolution[0]), int(resolution[1]))]
+    if not buckets:
+        raise ValueError("resolution list is empty")
+    return buckets


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->

This PR adds dataloader support for the NVPanoptix3Dv2 panoptic and reasoning variants.

The changes include:

- A model-type-aware data-module factory.
- A multi-view ScanNet++ panoptic dataset and Lightning data module.
- A JSONL-based reasoning dataset and Lightning data module.
- Geometry-safe multi-view photometric augmentation.
- Shared utilities for image transformation, panoptic-ID decoding, resolution handling, and configuration access.
- Deterministic validation sampling and distributed training support.

### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->

NVPanoptix3Dv2 supports two model variants with different dataset formats:

- The panoptic variant consumes preprocessed multi-view ScanNet++ scenes.
- The reasoning variant consumes instruction-based samples stored in JSONL manifests.

Previously, TAO PyTorch did not provide data loading, multi-view sampling, modality alignment, collation, or Lightning data-module integration for these workflows.

This change provides the data pipeline required to train, evaluate, and run inference with both NVPanoptix3Dv2 variants while maintaining a consistent view-major batch structure.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->

Part of TAOVN-1251

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->
Yes.

After this change, users can configure either a preprocessed ScanNet++ dataset for the panoptic variant or a JSONL reasoning manifest for the reasoning variant. The appropriate data module is selected automatically from `model.model_type`.

### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

Static checks were run on the new dataloader package:

```console
$ find nvidia_tao_pytorch/cv/nvpanoptix3d_v2/dataloader \
    -type f -name '*.py' -print0 |
  xargs -0 pre-commit run --files
```
### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->
Yes — portions were co-authored with an AI coding assistant.

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added multi-view ScanNet++ panoptic and JSONL reasoning dataloaders for NVPanoptix3Dv2.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [ ] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [ ] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->
A suggested review order is:

1. `dataloader/__init__.py` for model-type dispatch.
2. `dataloader/panoptic/pl_data_module.py` for ScanNet++ path validation, vocabulary loading, samplers, and Lightning integration.
3. `dataloader/panoptic/scannetpp.py` for multi-view sampling and modality loading.
4. `dataloader/panoptic/augmentations.py` for geometry-safe shared photometric augmentation.
5. `dataloader/reasoning/reasoning_dataset.py` for JSONL parsing, path resolution, view selection, and reasoning collation.
6. `dataloader/reasoning/pl_data_module.py` for reasoning loader construction.
7. `dataloader/utils.py` for the shared geometry, panoptic-ID, resolution, and configuration helpers.